### PR TITLE
feat(cuttings): Finish the cuttings library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Recorded Figma API responses: machine-generated, collapsed in PR diffs.
+packages/cuttings/src/__fixtures__/api/** linguist-generated=true

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,9 @@ flags:
   pkg-cache:
     paths:
       - packages/cache/
+  pkg-cuttings:
+    paths:
+      - packages/cuttings/
   pkg-eslint-plugin-figma:
     paths:
       - packages/eslint-plugin-figma/

--- a/packages/cuttings/README.md
+++ b/packages/cuttings/README.md
@@ -8,7 +8,7 @@
   
   
   <p>
-    <img src="https://img.shields.io/badge/status-TODO-red" alt="Status: to do" />
+    <img src="https://img.shields.io/badge/status-beta-yellow" alt="Status: beta" />
     <a href="https://github.com/Sidnioulz/figmarine/commits"><img src="https://img.shields.io/github/commit-activity/m/Sidnioulz/figmarine" alt="commit activity" /></a>
     <a href="https://github.com/Sidnioulz/figmarine/commits"><img src="https://img.shields.io/github/last-commit/Sidnioulz/figmarine" alt="last commit" /></a>
     <a href="https://github.com/Sidnioulz/figmarine/issues?q=is%3Aopen+is%3Aissue+label%3Apkg-cuttings"><img src="https://img.shields.io/github/issues-search?query=repo%3ASidnioulz%2Ffigmarine%20is%3Aopen%20is%3Aissue%20label%3Apkg-cuttings&label=issues" alt="open issues" /></a>
@@ -45,24 +45,94 @@
 
 ## :star2: Package Details
 
-> [!CAUTION]
-> Development on this package has not yet started.
+A cutting is a JSON snapshot of Figma content, fetched over the REST API and
+stored on disk. Like the botanical kind, you take a cutting once and keep it
+alive by re-hydrating it whenever you need fresh data. Cuttings power offline
+analysis of Figma files, such as linting them with `eslint-plugin-figma`,
+without paying an API round-trip on every run.
 
+### Usage
+
+```ts
+import { Client } from '@figmarine/rest';
+import { digCutting, hydrate, parseFigmaUrl, plantCutting, take } from '@figmarine/cuttings';
+
+const client = await Client({ personalAccessToken: process.env.FIGMA_PERSONAL_ACCESS_TOKEN });
+
+// Turn a Figma URL into a file key.
+const { fileKey } = parseFigmaUrl('https://www.figma.com/design/abc123/My-File');
+
+// Take a cutting: fetch the data described by each facet.
+const cutting = await take({
+  client,
+  label: 'My design system',
+  facets: [
+    { endpoint: 'GetFile', id: fileKey },
+    { endpoint: 'GetFileComponents', id: fileKey },
+    { endpoint: 'GetFileComponentSets', id: fileKey },
+    { endpoint: 'GetFileStyles', id: fileKey },
+  ],
+});
+
+// Plant it: store it on disk, pretty-printed for reviewable diffs.
+plantCutting(cutting, '.figmarine/cuttings/design-system.cutting.figmarine.json');
+
+// Later: dig it up and re-hydrate it with fresh data.
+const stored = digCutting('.figmarine/cuttings/design-system.cutting.figmarine.json');
+const fresh = await hydrate({ client, cutting: stored });
+plantCutting(fresh, stored.meta.lastKnownFilePath!);
+```
+
+### The cutting file format
+
+A cutting file is a JSON document with three top-level keys:
+
+- `meta`: a `label`, the `lastStored` timestamp, the `figmarineVersion` of
+  the format (currently `0`), and the `lastKnownFilePath` it was loaded from.
+- `facets`: the API calls needed to (re-)hydrate the cutting. Each facet has
+  an `endpoint` (e.g. `GetFile`), the `id` to pass to that endpoint (file
+  key, published component key, team id…), an optional `version` for
+  versioned endpoints, and the `lastHydrated` timestamp maintained by the
+  library.
+- `data`: dictionaries of fetched content, keyed by id — `files` (slimmed
+  `GetFile` bodies, keyed by file key), `components`, `componentSets` and
+  `styles` (published metadata keyed by their published `key`), plus
+  reserved dictionaries for variables, projects and future facet types.
+
+File data is slimmed before storage: volatile fields such as `thumbnailUrl`,
+`role` or `linkAccess` are dropped so that repeated hydrations of unchanged
+files produce empty diffs.
+
+### Supported facet endpoints
+
+`GetFile`, `GetFileComponents`, `GetFileComponentSets` and `GetFileStyles`
+are implemented. Other endpoint types declared in the schema (teams,
+projects, variables) are reserved and `take` throws a clear error for them.
+Variables endpoints require a Figma Enterprise plan and will come later.
+
+### Test fixtures
+
+The test suite runs against real recorded API responses stored in
+`src/__fixtures__/api/`. Regenerate them with
+`pnpm fixtures:regen` (requires `FIGMA_PERSONAL_ACCESS_TOKEN` and read access
+to the fixture files).
 
 ## :dart: Roadmap
 
-- [ ] Finalise cutting format (core file, facets)
+- [x] Finalise cutting format (core file, facets)
 - [ ] Optimise data overlap between some facets
 - [x] Write FS middleware to store and retrieve cuttings
-- [ ] Use REST API client to download cuttings
-- [ ] Create hydration helpers
-- [ ] Use zod for schema validation on FS-loaded files
-- [ ] Improve zod parse error printing
-- [ ] Add ability to name/describe cutting files and use the name in logs
-- [ ] Export Node.js library
-- [ ] Add unit tests
-- [ ] Document the library
-- [ ] Document the `figcutting.json` file format
+- [x] Use REST API client to download cuttings
+- [x] Create hydration helpers
+- [x] Use zod for schema validation on FS-loaded files
+- [x] Improve zod parse error printing
+- [x] Add ability to name/describe cutting files and use the name in logs
+- [x] Export Node.js library
+- [x] Add unit tests
+- [x] Document the library
+- [x] Document the cutting file format
+- [ ] Support team, project and variable facets
+- [ ] Facet options (depth, geometry, plugin_data)
 - [ ] Automate NPM releases
 
 

--- a/packages/cuttings/eslint.config.js
+++ b/packages/cuttings/eslint.config.js
@@ -1,4 +1,10 @@
 // /** @type {import("eslint").Linter.Config} */
 import { library } from '@figmarine/config-eslint';
 
-export default library;
+export default [
+  {
+    // Large recorded API responses; not worth linting.
+    ignores: ['src/__fixtures__/api/**/*.json'],
+  },
+  ...library,
+];

--- a/packages/cuttings/package.json
+++ b/packages/cuttings/package.json
@@ -20,9 +20,7 @@
   "homepage": "https://github.com/Sidnioulz/figmarine",
   "scripts": {
     "build": "tsup --env.NODE_ENV production",
-    "build:debug": "tsup --entry src/debug.ts --entry src/index.ts --env.NODE_ENV development",
     "dev": "tsc-watch --onSuccess \"tsup --env.NODE_ENV production\"",
-    "dev:debug": "tsc-watch --onSuccess \"tsup --entry src/debug.ts --entry src/index.ts --env.NODE_ENV development\"",
     "fixtures:regen": "node ./scripts/fetchFixtures.mjs",
     "lint": "eslint .",
     "lint:files": "eslint --",

--- a/packages/cuttings/package.json
+++ b/packages/cuttings/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-semantically-released",
   "license": "MIT",
   "type": "module",
-  "description": "Library to cache arbitrary data to disk for arbitrarily long",
+  "description": "Library that creates, stores and re-hydrates JSON snapshots of Figma content fetched over the REST API",
   "repository": {
     "type": "git",
     "url": "https://github.com/Sidnioulz/figmarine",
@@ -23,6 +23,7 @@
     "build:debug": "tsup --entry src/debug.ts --entry src/index.ts --env.NODE_ENV development",
     "dev": "tsc-watch --onSuccess \"tsup --env.NODE_ENV production\"",
     "dev:debug": "tsc-watch --onSuccess \"tsup --entry src/debug.ts --entry src/index.ts --env.NODE_ENV development\"",
+    "fixtures:regen": "node ./scripts/fetchFixtures.mjs",
     "lint": "eslint .",
     "lint:files": "eslint --",
     "lint:fix": "eslint . --fix",

--- a/packages/cuttings/scripts/fetchFixtures.mjs
+++ b/packages/cuttings/scripts/fetchFixtures.mjs
@@ -5,6 +5,18 @@
  * read access to the fixture files below. Run with:
  *
  *     pnpm --filter @figmarine/cuttings fixtures:regen
+ *
+ * The run takes a couple of minutes: the REST client rate-limits itself to
+ * 10 requests per minute and the script makes 12 — quiet pauses between
+ * files are expected, do not interrupt them.
+ *
+ * Two caveats about the recorded data:
+ * - Documents are depth-truncated (see FIXTURE_FILES), so `components` and
+ *   `styles` maps may reference node ids that lie beyond the recorded
+ *   depth. Real cuttings are always taken at full depth.
+ * - Volatile per-request fields (signed thumbnail URLs, the requester's
+ *   role) are normalised below so regeneration against unchanged Figma
+ *   files produces no diff.
  */
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -23,6 +35,34 @@ const FIXTURE_FILES = [
 ];
 
 const OUTPUT_DIR = path.resolve(import.meta.dirname, '../src/__fixtures__/api');
+
+const STABLE_THUMBNAIL = 'https://figma-thumbnails.example/redacted';
+
+/**
+ * Normalises fields that differ on every request or per requester, so
+ * that regenerating fixtures against unchanged Figma files is a no-op.
+ */
+function stabilize(body) {
+  if (typeof body.thumbnailUrl === 'string') {
+    body.thumbnailUrl = STABLE_THUMBNAIL;
+  }
+  if (typeof body.role === 'string') {
+    body.role = 'viewer';
+  }
+  for (const branch of body.branches ?? []) {
+    if (typeof branch.thumbnail_url === 'string') {
+      branch.thumbnail_url = STABLE_THUMBNAIL;
+    }
+  }
+  for (const items of Object.values(body.meta ?? {})) {
+    for (const item of Array.isArray(items) ? items : []) {
+      if (typeof item.thumbnail_url === 'string') {
+        item.thumbnail_url = STABLE_THUMBNAIL;
+      }
+    }
+  }
+  return body;
+}
 
 const client = await Client({ cache: false, mode: 'production', rateLimit: true });
 
@@ -44,10 +84,10 @@ for (const { label, fileKey, depth } of FIXTURE_FILES) {
     client.v1.getFileStyles(fileKey),
   ]);
 
-  await saveFixture(label, 'GetFile', file.data);
-  await saveFixture(label, 'GetFileComponents', components.data);
-  await saveFixture(label, 'GetFileComponentSets', componentSets.data);
-  await saveFixture(label, 'GetFileStyles', styles.data);
+  await saveFixture(label, 'GetFile', stabilize(file.data));
+  await saveFixture(label, 'GetFileComponents', stabilize(components.data));
+  await saveFixture(label, 'GetFileComponentSets', stabilize(componentSets.data));
+  await saveFixture(label, 'GetFileStyles', stabilize(styles.data));
 }
 
 console.log('All fixtures regenerated.');

--- a/packages/cuttings/scripts/fetchFixtures.mjs
+++ b/packages/cuttings/scripts/fetchFixtures.mjs
@@ -11,10 +11,15 @@ import path from 'node:path';
 
 import { Client } from '@figmarine/rest';
 
+/**
+ * Full document trees for these files weigh 48MB to 400MB, far beyond what
+ * a repository should carry, so each file is recorded at the deepest depth
+ * that keeps its GetFile fixture in the hundreds-of-kilobytes range.
+ */
 const FIXTURE_FILES = [
-  { label: 'figma-api-debug-file', fileKey: 'idLa6ZCXDJUeRFI5wLVNWN' },
-  { label: 'error-states', fileKey: '3qv1uKfLSXm4etqj005Rmi' },
-  { label: 'surface-new-stories', fileKey: 'pMmZ9LmqB0KbgI8GNY4IW9' },
+  { label: 'figma-api-debug-file', fileKey: 'idLa6ZCXDJUeRFI5wLVNWN', depth: 4 },
+  { label: 'error-states', fileKey: '3qv1uKfLSXm4etqj005Rmi', depth: 3 },
+  { label: 'surface-new-stories', fileKey: 'pMmZ9LmqB0KbgI8GNY4IW9', depth: 2 },
 ];
 
 const OUTPUT_DIR = path.resolve(import.meta.dirname, '../src/__fixtures__/api');
@@ -29,11 +34,11 @@ async function saveFixture(label, endpoint, data) {
   console.log(`Saved ${path.relative(process.cwd(), file)}`);
 }
 
-for (const { label, fileKey } of FIXTURE_FILES) {
+for (const { label, fileKey, depth } of FIXTURE_FILES) {
   console.log(`Fetching fixture data for '${label}' (${fileKey})…`);
 
   const [file, components, componentSets, styles] = await Promise.all([
-    client.v1.getFile(fileKey, { branch_data: true }),
+    client.v1.getFile(fileKey, { branch_data: true, depth }),
     client.v1.getFileComponents(fileKey),
     client.v1.getFileComponentSets(fileKey),
     client.v1.getFileStyles(fileKey),

--- a/packages/cuttings/scripts/fetchFixtures.mjs
+++ b/packages/cuttings/scripts/fetchFixtures.mjs
@@ -1,0 +1,48 @@
+/**
+ * Regenerates the real-data API fixtures used by the cuttings test suite.
+ *
+ * Requires FIGMA_PERSONAL_ACCESS_TOKEN (or FIGMA_OAUTH_TOKEN) to be set, and
+ * read access to the fixture files below. Run with:
+ *
+ *     pnpm --filter @figmarine/cuttings fixtures:regen
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { Client } from '@figmarine/rest';
+
+const FIXTURE_FILES = [
+  { label: 'figma-api-debug-file', fileKey: 'idLa6ZCXDJUeRFI5wLVNWN' },
+  { label: 'error-states', fileKey: '3qv1uKfLSXm4etqj005Rmi' },
+  { label: 'surface-new-stories', fileKey: 'pMmZ9LmqB0KbgI8GNY4IW9' },
+];
+
+const OUTPUT_DIR = path.resolve(import.meta.dirname, '../src/__fixtures__/api');
+
+const client = await Client({ cache: false, mode: 'production', rateLimit: true });
+
+async function saveFixture(label, endpoint, data) {
+  const dir = path.join(OUTPUT_DIR, label);
+  await mkdir(dir, { recursive: true });
+  const file = path.join(dir, `${endpoint}.json`);
+  await writeFile(file, `${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+  console.log(`Saved ${path.relative(process.cwd(), file)}`);
+}
+
+for (const { label, fileKey } of FIXTURE_FILES) {
+  console.log(`Fetching fixture data for '${label}' (${fileKey})…`);
+
+  const [file, components, componentSets, styles] = await Promise.all([
+    client.v1.getFile(fileKey, { branch_data: true }),
+    client.v1.getFileComponents(fileKey),
+    client.v1.getFileComponentSets(fileKey),
+    client.v1.getFileStyles(fileKey),
+  ]);
+
+  await saveFixture(label, 'GetFile', file.data);
+  await saveFixture(label, 'GetFileComponents', components.data);
+  await saveFixture(label, 'GetFileComponentSets', componentSets.data);
+  await saveFixture(label, 'GetFileStyles', styles.data);
+}
+
+console.log('All fixtures regenerated.');

--- a/packages/cuttings/src/__fixtures__/api.ts
+++ b/packages/cuttings/src/__fixtures__/api.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * Labels of the real Figma files used as test fixtures. Regenerate their
+ * data with `pnpm fixtures:regen` (requires FIGMA_PERSONAL_ACCESS_TOKEN).
+ */
+export const API_FIXTURE_FILES = {
+  'figma-api-debug-file': 'idLa6ZCXDJUeRFI5wLVNWN',
+  'error-states': '3qv1uKfLSXm4etqj005Rmi',
+  'surface-new-stories': 'pMmZ9LmqB0KbgI8GNY4IW9',
+} as const;
+
+export type ApiFixtureLabel = keyof typeof API_FIXTURE_FILES;
+export type ApiFixtureEndpoint =
+  'GetFile' | 'GetFileComponents' | 'GetFileComponentSets' | 'GetFileStyles';
+
+/**
+ * Loads a real Figma REST API response recorded by scripts/fetchFixtures.mjs.
+ * Reads from disk on purpose: these files are large, and importing them as
+ * modules would slow type checking down considerably.
+ */
+export function loadApiFixture<T>(label: ApiFixtureLabel, endpoint: ApiFixtureEndpoint): T {
+  const url = new URL(`./api/${label}/${endpoint}.json`, import.meta.url);
+
+  return JSON.parse(readFileSync(url, 'utf-8')) as T;
+}

--- a/packages/cuttings/src/__fixtures__/api/error-states/GetFile.json
+++ b/packages/cuttings/src/__fixtures__/api/error-states/GetFile.json
@@ -16812,9 +16812,9 @@
   },
   "name": "Error States",
   "lastModified": "2026-04-09T16:26:21Z",
-  "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/6adb7997-dfda-41f0-927c-c710ce5696e6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWCZHCZBGZX%2F20260705%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260705T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=aca5b573694a1673839d7b63851853649ff853739226b2a1a6c7bf76a812377a",
+  "thumbnailUrl": "https://figma-thumbnails.example/redacted",
   "version": "2340494070937107033",
-  "role": "editor",
+  "role": "viewer",
   "editorType": "figma",
   "linkAccess": "inherit"
 }

--- a/packages/cuttings/src/__fixtures__/api/error-states/GetFile.json
+++ b/packages/cuttings/src/__fixtures__/api/error-states/GetFile.json
@@ -1,0 +1,16820 @@
+{
+  "document": {
+    "id": "0:0",
+    "name": "Document",
+    "type": "DOCUMENT",
+    "scrollBehavior": "SCROLLS",
+    "children": [
+      {
+        "id": "207:48305",
+        "name": "Proposal",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "207:49400",
+            "name": "Proposal",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:c2b42f4e95ad77909b30a3d20b1f94b85e89351b/463:117"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:48307",
+                "name": "Render error",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 100,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 100,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "296:15239",
+                "name": "404",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 2820,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 2820,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:48339",
+                "name": "Render error: Overflow",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 1460,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 1460,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:36204",
+                "name": "Docs error",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 4180,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 1729
+                },
+                "absoluteRenderBounds": {
+                  "x": 4180,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 1729
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:32242",
+                "name": "Error modal",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 5540,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": 5540,
+                  "y": 1642,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "HUG",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:35324",
+                "name": "Error modal",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 5540,
+                  "y": 2684,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": 5540,
+                  "y": 2684,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "HUG",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.3607843220233917,
+                  "g": 0.40784314274787903,
+                  "b": 0.43921568989753723,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:c2b42f4e95ad77909b30a3d20b1f94b85e89351b/463:117"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 1542,
+              "width": 6900,
+              "height": 2184
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 1542,
+              "width": 6900,
+              "height": 2184
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "219:34000",
+            "name": "Current",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:71413b4a6fa4b229575ba63428c24d02ad2caec1/463:112"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "219:33995",
+                "name": "image 6",
+                "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "IMAGE",
+                    "scaleMode": "FILL",
+                    "imageRef": "deadc6c1f740b74450bda4e96f5e72378a1d3853"
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 4162,
+                  "y": 100,
+                  "width": 1283,
+                  "height": 877
+                },
+                "absoluteRenderBounds": {
+                  "x": 4162,
+                  "y": 100,
+                  "width": 1283,
+                  "height": 877
+                },
+                "preserveRatio": true,
+                "targetAspectRatio": {
+                  "x": 2566,
+                  "y": 1754
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:27820",
+                "name": "image 4",
+                "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "IMAGE",
+                    "scaleMode": "FILL",
+                    "imageRef": "591b293e5024b69c149f6555ba8b4afcf9f067e3"
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2758,
+                  "y": 100,
+                  "width": 1371,
+                  "height": 893
+                },
+                "absoluteRenderBounds": {
+                  "x": 2758,
+                  "y": 100,
+                  "width": 1371,
+                  "height": 893
+                },
+                "preserveRatio": true,
+                "targetAspectRatio": {
+                  "x": 2742,
+                  "y": 1786
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:32241",
+                "name": "Error modal",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                    }
+                  ]
+                },
+                "componentId": "207:37095",
+                "overrides": [],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 5515,
+                  "y": 100,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": 5515,
+                  "y": 100,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "HUG",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:33998",
+                "name": "image 7",
+                "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "IMAGE",
+                    "scaleMode": "FILL",
+                    "imageRef": "268bcc062217f56c33e1951a956e289e18eda622"
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 100,
+                  "y": 100,
+                  "width": 1272,
+                  "height": 867
+                },
+                "absoluteRenderBounds": {
+                  "x": 100,
+                  "y": 100,
+                  "width": 1272,
+                  "height": 867
+                },
+                "preserveRatio": true,
+                "targetAspectRatio": {
+                  "x": 2544,
+                  "y": 1734
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.45098039507865906,
+                  "g": 0.5098039507865906,
+                  "b": 0.5490196347236633,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:71413b4a6fa4b229575ba63428c24d02ad2caec1/463:112"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": -2.2737367544323206e-13,
+              "width": 6875,
+              "height": 1142
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": -2.2737367544323206e-13,
+              "width": 6875,
+              "height": 1142
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "207:48306",
+        "name": "---",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "0:1",
+        "name": "Sketches",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "1:547",
+            "name": "formatted error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "1:548",
+                "name": "Ellipse 1",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 221,
+                  "y": 8610,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 8610,
+                  "width": 689,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:549",
+                "name": "Ellipse 2",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7546666860580444,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7529411911964417,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 221,
+                  "y": 7648,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 8586,
+                  "width": 689,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:550",
+                "name": "Ellipse 5",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1120,
+                  "y": 7648,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 8586,
+                  "width": 1317,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:551",
+                "name": "Ellipse 6",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1120,
+                  "y": 8610,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 8610,
+                  "width": 1317,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:552",
+                "name": "Ellipse 3",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.5626665353775024,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.5607843399047852,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2020,
+                  "y": 7648,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 2020,
+                  "y": 8586,
+                  "width": 660,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:553",
+                "name": "Ellipse 4",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.46666663885116577,
+                          "g": 1,
+                          "b": 0.968000054359436,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.46666666865348816,
+                          "g": 1,
+                          "b": 0.9686274528503418,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2020,
+                  "y": 8610,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 2020,
+                  "y": 8610,
+                  "width": 660,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:554",
+                "name": "Add design assets",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "cornerRadius": 8,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "styles": {
+                  "strokes": "1:509",
+                  "stroke": "1:509"
+                },
+                "absoluteBoundingBox": {
+                  "x": 1419,
+                  "y": 8640,
+                  "width": 1202,
+                  "height": 832
+                },
+                "absoluteRenderBounds": {
+                  "x": 1379,
+                  "y": 8620,
+                  "width": 1282,
+                  "height": 906
+                },
+                "constraints": {
+                  "vertical": "SCALE",
+                  "horizontal": "SCALE"
+                },
+                "effects": [
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "radius": 3,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 10
+                    },
+                    "radius": 20,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 20
+                    },
+                    "radius": 40,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 40
+                    },
+                    "radius": 30,
+                    "showShadowBehindNode": true
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "styles": {
+              "fills": "1:508",
+              "fill": "1:508"
+            },
+            "absoluteBoundingBox": {
+              "x": 1363,
+              "y": 8586,
+              "width": 1317,
+              "height": 940
+            },
+            "absoluteRenderBounds": {
+              "x": 1363,
+              "y": 8586,
+              "width": 1317,
+              "height": 940
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "exportSettings": [
+              {
+                "suffix": "",
+                "format": "JPG",
+                "constraint": {
+                  "type": "SCALE",
+                  "value": 1
+                }
+              }
+            ],
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "1:585",
+            "name": "known error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "1:586",
+                "name": "Ellipse 1",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 226,
+                  "y": 7593,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1368,
+                  "y": 7593,
+                  "width": 689,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:587",
+                "name": "Ellipse 2",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7546666860580444,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7529411911964417,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 226,
+                  "y": 6631,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1368,
+                  "y": 7569,
+                  "width": 689,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:588",
+                "name": "Ellipse 5",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1125,
+                  "y": 6631,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1368,
+                  "y": 7569,
+                  "width": 1312,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:589",
+                "name": "Ellipse 6",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1125,
+                  "y": 7593,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1368,
+                  "y": 7593,
+                  "width": 1312,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:590",
+                "name": "Ellipse 3",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.5626665353775024,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.5607843399047852,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2025,
+                  "y": 6631,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 2025,
+                  "y": 7569,
+                  "width": 655,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:591",
+                "name": "Ellipse 4",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.46666663885116577,
+                          "g": 1,
+                          "b": 0.968000054359436,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.46666666865348816,
+                          "g": 1,
+                          "b": 0.9686274528503418,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2025,
+                  "y": 7593,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 2025,
+                  "y": 7593,
+                  "width": 655,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:592",
+                "name": "Add design assets",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "cornerRadius": 8,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "styles": {
+                  "strokes": "1:509",
+                  "stroke": "1:509"
+                },
+                "absoluteBoundingBox": {
+                  "x": 1424,
+                  "y": 7623,
+                  "width": 1202,
+                  "height": 832
+                },
+                "absoluteRenderBounds": {
+                  "x": 1384,
+                  "y": 7603,
+                  "width": 1282,
+                  "height": 906
+                },
+                "constraints": {
+                  "vertical": "SCALE",
+                  "horizontal": "SCALE"
+                },
+                "effects": [
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "radius": 3,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 10
+                    },
+                    "radius": 20,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 20
+                    },
+                    "radius": 40,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 40
+                    },
+                    "radius": 30,
+                    "showShadowBehindNode": true
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "styles": {
+              "fills": "1:508",
+              "fill": "1:508"
+            },
+            "absoluteBoundingBox": {
+              "x": 1368,
+              "y": 7569,
+              "width": 1312,
+              "height": 940
+            },
+            "absoluteRenderBounds": {
+              "x": 1368,
+              "y": 7569,
+              "width": 1312,
+              "height": 940
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "exportSettings": [
+              {
+                "suffix": "",
+                "format": "JPG",
+                "constraint": {
+                  "type": "SCALE",
+                  "value": 1
+                }
+              }
+            ],
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "1:630",
+            "name": "unformatted error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "1:631",
+                "name": "Ellipse 1",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 221,
+                  "y": 9627,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 9627,
+                  "width": 689,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:632",
+                "name": "Ellipse 2",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7546666860580444,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7529411911964417,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 221,
+                  "y": 8665,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 9603,
+                  "width": 689,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:633",
+                "name": "Ellipse 5",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1120,
+                  "y": 8665,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 9603,
+                  "width": 1317,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:634",
+                "name": "Ellipse 6",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1120,
+                  "y": 9627,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 1363,
+                  "y": 9627,
+                  "width": 1317,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:635",
+                "name": "Ellipse 3",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.5626665353775024,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.5607843399047852,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2020,
+                  "y": 8665,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 2020,
+                  "y": 9603,
+                  "width": 660,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:636",
+                "name": "Ellipse 4",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.46666663885116577,
+                          "g": 1,
+                          "b": 0.968000054359436,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.46666666865348816,
+                          "g": 1,
+                          "b": 0.9686274528503418,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 2020,
+                  "y": 9627,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": 2020,
+                  "y": 9627,
+                  "width": 660,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:637",
+                "name": "Add design assets",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "cornerRadius": 8,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "styles": {
+                  "strokes": "1:509",
+                  "stroke": "1:509"
+                },
+                "absoluteBoundingBox": {
+                  "x": 1419,
+                  "y": 9657,
+                  "width": 1202,
+                  "height": 832
+                },
+                "absoluteRenderBounds": {
+                  "x": 1379,
+                  "y": 9637,
+                  "width": 1282,
+                  "height": 906
+                },
+                "constraints": {
+                  "vertical": "SCALE",
+                  "horizontal": "SCALE"
+                },
+                "effects": [
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "radius": 3,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 10
+                    },
+                    "radius": 20,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 20
+                    },
+                    "radius": 40,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 40
+                    },
+                    "radius": 30,
+                    "showShadowBehindNode": true
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:668",
+                "name": "Rectangle 91",
+                "type": "RECTANGLE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.13333334028720856,
+                      "g": 0.1411764770746231,
+                      "b": 0.14509804546833038,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": 1504,
+                  "y": 10543,
+                  "width": 146,
+                  "height": 138
+                },
+                "absoluteRenderBounds": {
+                  "x": 1504,
+                  "y": 10543,
+                  "width": 146,
+                  "height": 0
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "styles": {
+              "fills": "1:508",
+              "fill": "1:508"
+            },
+            "absoluteBoundingBox": {
+              "x": 1363,
+              "y": 9603,
+              "width": 1317,
+              "height": 940
+            },
+            "absoluteRenderBounds": {
+              "x": 1363,
+              "y": 9603,
+              "width": 1317,
+              "height": 940
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "exportSettings": [
+              {
+                "suffix": "",
+                "format": "JPG",
+                "constraint": {
+                  "type": "SCALE",
+                  "value": 1
+                }
+              }
+            ],
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "1:669",
+            "name": "story not found",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "1:670",
+                "name": "Ellipse 1",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": -2956,
+                  "y": 7593,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": -1815,
+                  "y": 7593,
+                  "width": 690,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:671",
+                "name": "Ellipse 2",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7546666860580444,
+                          "b": 0.46666663885116577,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.7529411911964417,
+                          "b": 0.46666666865348816,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": -2956,
+                  "y": 6631,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": -1815,
+                  "y": 7569,
+                  "width": 690,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:672",
+                "name": "Ellipse 5",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": -2057,
+                  "y": 6631,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": -1815,
+                  "y": 7569,
+                  "width": 1318,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:673",
+                "name": "Ellipse 6",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.9915000200271606,
+                          "g": 1,
+                          "b": 0.574999988079071,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.9921568632125854,
+                          "g": 1,
+                          "b": 0.5764706134796143,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": -2057,
+                  "y": 7593,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": -1815,
+                  "y": 7593,
+                  "width": 1318,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:674",
+                "name": "Ellipse 3",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666663885116577,
+                          "b": 0.5626665353775024,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 1,
+                          "g": 0.46666666865348816,
+                          "b": 0.5607843399047852,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": -1157,
+                  "y": 6631,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": -1157,
+                  "y": 7569,
+                  "width": 660,
+                  "height": 893
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:675",
+                "name": "Ellipse 4",
+                "type": "ELLIPSE",
+                "scrollBehavior": "SCROLLS",
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "GRADIENT_RADIAL",
+                    "gradientHandlePositions": [
+                      {
+                        "x": 0.5,
+                        "y": 0.49999999999999994
+                      },
+                      {
+                        "x": 0.5,
+                        "y": 0.9999999999999999
+                      },
+                      {
+                        "x": 0,
+                        "y": 0.5
+                      }
+                    ],
+                    "gradientStops": [
+                      {
+                        "color": {
+                          "r": 0.46666663885116577,
+                          "g": 1,
+                          "b": 0.968000054359436,
+                          "a": 1
+                        },
+                        "position": 0
+                      },
+                      {
+                        "color": {
+                          "r": 0.46666666865348816,
+                          "g": 1,
+                          "b": 0.9686274528503418,
+                          "a": 0
+                        },
+                        "position": 1
+                      }
+                    ]
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "absoluteBoundingBox": {
+                  "x": -1157,
+                  "y": 7593,
+                  "width": 1831,
+                  "height": 1831
+                },
+                "absoluteRenderBounds": {
+                  "x": -1157,
+                  "y": 7593,
+                  "width": 660,
+                  "height": 916
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "arcData": {
+                  "startingAngle": 0,
+                  "endingAngle": 6.2831854820251465,
+                  "innerRadius": 0
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "1:676",
+                "name": "Add design assets",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "cornerRadius": 8,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "styles": {
+                  "strokes": "1:509",
+                  "stroke": "1:509"
+                },
+                "absoluteBoundingBox": {
+                  "x": -1758,
+                  "y": 7623,
+                  "width": 1202,
+                  "height": 832
+                },
+                "absoluteRenderBounds": {
+                  "x": -1798,
+                  "y": 7603,
+                  "width": 1282,
+                  "height": 906
+                },
+                "constraints": {
+                  "vertical": "SCALE",
+                  "horizontal": "SCALE"
+                },
+                "effects": [
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "radius": 3,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 10
+                    },
+                    "radius": 20,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 20
+                    },
+                    "radius": 40,
+                    "showShadowBehindNode": true
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 40
+                    },
+                    "radius": 30,
+                    "showShadowBehindNode": true
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "styles": {
+              "fills": "1:508",
+              "fill": "1:508"
+            },
+            "absoluteBoundingBox": {
+              "x": -1815,
+              "y": 7569,
+              "width": 1318,
+              "height": 940
+            },
+            "absoluteRenderBounds": {
+              "x": -1815,
+              "y": 7569,
+              "width": 1318,
+              "height": 940
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "exportSettings": [
+              {
+                "suffix": "",
+                "format": "PNG",
+                "constraint": {
+                  "type": "SCALE",
+                  "value": 1
+                }
+              }
+            ],
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:19558",
+            "name": "Button",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "componentId": "207:29822",
+            "componentProperties": {
+              "Show Sidebar#1319:1": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Show Addon panel#1319:0": {
+                "type": "BOOLEAN",
+                "value": true
+              }
+            },
+            "overrides": [],
+            "children": [
+              {
+                "id": "I202:19558;1311:31726",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "componentPropertyReferences": {
+                  "visible": "Show Sidebar#1319:1"
+                },
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -7684,
+                  "y": -2804,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -7684,
+                  "y": -2804,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "I202:19558;1311:31727",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -7434,
+                  "y": -2804,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -7434,
+                  "y": -2804,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -7684,
+              "y": -2804,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -7684,
+              "y": -2804,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:21674",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "202:21675",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "202:21675",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": -2804,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": -2804,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:21676",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": -2804,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": -2804,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": -2804,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": -2804,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:28765",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "202:28766",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "202:28766",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I202:28766;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:28766;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:28766;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:28766;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": -1034,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": -1034,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:28767",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": -1034,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": -1034,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": -1034,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": -1034,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:29303",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "202:29304",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "202:29304",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I202:29304;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:29304;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:29304;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:29304;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 36,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 36,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:29305",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 36,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 36,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 36,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 36,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:29886",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "202:29887",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "202:29887",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I202:29887;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:29887;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:29887;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:29887;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 1106,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 1106,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:29888",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 1106,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 1106,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 1106,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 1106,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:30371",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "202:30372",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "202:30372",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I202:30372;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:30372;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:30372;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I202:30372;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 2176,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 2176,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:30373",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 2176,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 2176,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 2176,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 2176,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:18178",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:18179",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:18179",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:18179;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:18179;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:18179;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:18179;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 3246,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 3246,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:18180",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 3246,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 3246,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 3246,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 3246,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:18667",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:18668",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:18668",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:18668;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:18668;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:18668;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:18668;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 4316,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 4316,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:18669",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 4316,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 4316,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 4316,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 4316,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:19706",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:19707",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:19707",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:19707;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:19707;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:19707;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:19707;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 5386,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 5386,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:19708",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 5386,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 5386,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 5386,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 5386,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:21702",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:21703",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:21703",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:21703;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:21703;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:21703;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:21703;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 6456,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 6456,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:21704",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 6456,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 6456,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 6456,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 6456,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:46852",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:46853",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:46853",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:46853;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:46853;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:46853;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:46853;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 7526,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 7526,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:46854",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 7526,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 7526,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 7526,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 7526,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "214:20210",
+            "name": "Render error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "214:20211",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "214:20211",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I214:20211;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I214:20211;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I214:20211;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I214:20211;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -6224,
+                  "y": 8562,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -6224,
+                  "y": 8562,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "214:20212",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "itemSpacing": 1,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -5974,
+                  "y": 8562,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -5974,
+                  "y": 8562,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -6224,
+              "y": 8562,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -6224,
+              "y": 8562,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "217:21610",
+            "name": "Most likely a border would look like this (next to grey borders)",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "217:21611",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "217:21611",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I217:21611;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I217:21611;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I217:21611;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I217:21611;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4815,
+                  "y": 8562,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -4815,
+                  "y": 8562,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "217:21612",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "strokesIncludedInLayout": true,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4565,
+                  "y": 8562,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -4565,
+                  "y": 8562,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4815,
+              "y": 8562,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -4815,
+              "y": 8562,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:47687",
+            "name": "404",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:47688",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:47688",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:47688;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:47688;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:47688;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:47688;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -3504,
+                  "y": 7526,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -3504,
+                  "y": 7526,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:47689",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -3254,
+                  "y": 7526,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -3254,
+                  "y": 7526,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -3504,
+              "y": 7526,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -3504,
+              "y": 7526,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:20892",
+            "name": "Render error: Overflow",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "207:20893",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "207:20893",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I207:20893;1234:36393",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:20893;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:20893;1248:25012;1233:16331",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I207:20893;1248:25012;1233:16331;1233:12189",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4864,
+                  "y": 7526,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -4864,
+                  "y": 7526,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:20894",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4614,
+                  "y": 7526,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -4614,
+                  "y": 7526,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4864,
+              "y": 7526,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -4864,
+              "y": 7526,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:20543",
+            "name": "Frame 654",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "207:20699",
+                "name": "Toolbar",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 1,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingRight": 10,
+                "itemSpacing": 24,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4609,
+                  "y": 5126,
+                  "width": 962,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -4609,
+                  "y": 5126,
+                  "width": 962,
+                  "height": 40
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:20852",
+                "name": "Toolbar",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 1,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingRight": 10,
+                "itemSpacing": 24,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4609,
+                  "y": 5166,
+                  "width": 962,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -4609,
+                  "y": 5166,
+                  "width": 962,
+                  "height": 40
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:20775",
+                "name": "Toolbar",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 1,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "paddingRight": 10,
+                "itemSpacing": 24,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4609,
+                  "y": 5206,
+                  "width": 962,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -4609,
+                  "y": 5206,
+                  "width": 962,
+                  "height": 40
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "207:20545",
+                "name": "Toolbar",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 1,
+                  "right": 0,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "paddingRight": 10,
+                "itemSpacing": 24,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4609,
+                  "y": 5246,
+                  "width": 962,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -4609,
+                  "y": 5246,
+                  "width": 962,
+                  "height": 40
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.1417643278837204,
+                  "g": 0.1417643278837204,
+                  "b": 0.1417643278837204,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.1417643278837204,
+                  "g": 0.1417643278837204,
+                  "b": 0.1417643278837204,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.1417643278837204,
+              "g": 0.1417643278837204,
+              "b": 0.1417643278837204,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4609,
+              "y": 5126,
+              "width": 962,
+              "height": 160
+            },
+            "absoluteRenderBounds": {
+              "x": -4609,
+              "y": 5126,
+              "width": 962,
+              "height": 160
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:31326",
+            "name": "image 2",
+            "type": "RECTANGLE",
+            "scrollBehavior": "SCROLLS",
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "IMAGE",
+                "scaleMode": "FILL",
+                "imageRef": "ea1f26809a0ae690320f9fbeacaa6a552b143009"
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -4345,
+              "y": 2029,
+              "width": 363,
+              "height": 207
+            },
+            "absoluteRenderBounds": {
+              "x": -4345,
+              "y": 2029,
+              "width": 363,
+              "height": 207
+            },
+            "preserveRatio": true,
+            "targetAspectRatio": {
+              "x": 726,
+              "y": 414
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "1:701",
+            "name": "Error proposal",
+            "type": "TEXT",
+            "scrollBehavior": "SCROLLS",
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "absoluteBoundingBox": {
+              "x": 1363,
+              "y": 7303,
+              "width": 661,
+              "height": 131
+            },
+            "absoluteRenderBounds": {
+              "x": 1369.8160400390625,
+              "y": 7332.31982421875,
+              "width": 652.970947265625,
+              "height": 84.9599609375
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "characters": "Error proposal",
+            "characterStyleOverrides": [],
+            "styleOverrideTable": {},
+            "lineTypes": [
+              "NONE"
+            ],
+            "lineIndentations": [
+              0
+            ],
+            "style": {
+              "fontFamily": "Nunito Sans",
+              "fontPostScriptName": "NunitoSans-ExtraBold",
+              "fontStyle": "ExtraBold",
+              "fontWeight": 800,
+              "textAutoResize": "WIDTH_AND_HEIGHT",
+              "fontSize": 96,
+              "textAlignHorizontal": "LEFT",
+              "textAlignVertical": "TOP",
+              "letterSpacing": 0,
+              "lineHeightPx": 130.94400024414062,
+              "lineHeightPercent": 100,
+              "lineHeightUnit": "INTRINSIC_%"
+            },
+            "layoutVersion": 3,
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "1:702",
+            "name": "404 proposal",
+            "type": "TEXT",
+            "scrollBehavior": "SCROLLS",
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "absoluteBoundingBox": {
+              "x": -1817,
+              "y": 7303,
+              "width": 602,
+              "height": 131
+            },
+            "absoluteRenderBounds": {
+              "x": -1813.5439453125,
+              "y": 7331.26416015625,
+              "width": 596.5184326171875,
+              "height": 86.015625
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "characters": "404 proposal",
+            "characterStyleOverrides": [],
+            "styleOverrideTable": {},
+            "lineTypes": [
+              "NONE"
+            ],
+            "lineIndentations": [
+              0
+            ],
+            "style": {
+              "fontFamily": "Nunito Sans",
+              "fontPostScriptName": "NunitoSans-ExtraBold",
+              "fontStyle": "ExtraBold",
+              "fontWeight": 800,
+              "textAutoResize": "WIDTH_AND_HEIGHT",
+              "fontSize": 96,
+              "textAlignHorizontal": "LEFT",
+              "textAlignVertical": "TOP",
+              "letterSpacing": 0,
+              "lineHeightPx": 130.94400024414062,
+              "lineHeightPercent": 100,
+              "lineHeightUnit": "INTRINSIC_%"
+            },
+            "layoutVersion": 3,
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:2321",
+            "name": "Error - Known error 2",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                }
+              ]
+            },
+            "explicitVariableModes": {
+              "VariableCollectionId:eadeca2af7463f0a0d10d1502f4ab1fb397e91a6/12:233": "12:3"
+            },
+            "children": [
+              {
+                "id": "202:2322",
+                "name": "Sidebar",
+                "type": "FRAME",
+                "locked": true,
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:65761f9cf0720fd19b5f1d45bec24418e47ec38c/463:163"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:65761f9cf0720fd19b5f1d45bec24418e47ec38c/463:163"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "itemSpacing": 71,
+                "layoutWrap": "WRAP",
+                "counterAxisSpacing": 0,
+                "counterAxisAlignContent": "AUTO",
+                "absoluteBoundingBox": {
+                  "x": 3266,
+                  "y": 7667,
+                  "width": 250,
+                  "height": 980
+                },
+                "absoluteRenderBounds": {
+                  "x": 3266,
+                  "y": 7667,
+                  "width": 250,
+                  "height": 980
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:2368",
+                "name": "Frame 334",
+                "type": "FRAME",
+                "locked": true,
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 3516,
+                  "y": 7667,
+                  "width": 950,
+                  "height": 979
+                },
+                "absoluteRenderBounds": {
+                  "x": 3516,
+                  "y": 7667,
+                  "width": 950,
+                  "height": 979
+                },
+                "constraints": {
+                  "vertical": "TOP_BOTTOM",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:2434",
+                "name": "Frame 392",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "absoluteBoundingBox": {
+                  "x": 3516,
+                  "y": 7707,
+                  "width": 950,
+                  "height": 587
+                },
+                "absoluteRenderBounds": {
+                  "x": 3516,
+                  "y": 7707,
+                  "width": 950,
+                  "height": 587
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "absoluteBoundingBox": {
+              "x": 3266,
+              "y": 7667,
+              "width": 1200,
+              "height": 980
+            },
+            "absoluteRenderBounds": {
+              "x": 3266,
+              "y": 7667,
+              "width": 1200,
+              "height": 980
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "exportSettings": [
+              {
+                "suffix": "",
+                "format": "JPG",
+                "constraint": {
+                  "type": "SCALE",
+                  "value": 1
+                }
+              }
+            ],
+            "effects": [],
+            "interactions": [
+              {
+                "trigger": {
+                  "type": "ON_CLICK"
+                },
+                "actions": [
+                  {
+                    "type": "NODE",
+                    "destinationId": null,
+                    "navigation": "NAVIGATE",
+                    "transition": null
+                  }
+                ]
+              }
+            ],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:4272",
+            "name": "Broken",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "202:4273",
+                "name": "Storybook 5",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                    }
+                  ]
+                },
+                "explicitVariableModes": {
+                  "VariableCollectionId:eadeca2af7463f0a0d10d1502f4ab1fb397e91a6/12:233": "12:3"
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "absoluteBoundingBox": {
+                  "x": 3266,
+                  "y": 8803,
+                  "width": 1200,
+                  "height": 800
+                },
+                "absoluteRenderBounds": {
+                  "x": 3266,
+                  "y": 8803,
+                  "width": 1200,
+                  "height": 800
+                },
+                "constraints": {
+                  "vertical": "TOP_BOTTOM",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9700000286102295,
+                  "g": 0.9822869896888733,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9700000286102295,
+                  "g": 0.9822869896888733,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9700000286102295,
+              "g": 0.9822869896888733,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "styles": {
+              "fills": "1:510",
+              "fill": "1:510"
+            },
+            "absoluteBoundingBox": {
+              "x": 3266,
+              "y": 8803,
+              "width": 1200,
+              "height": 800
+            },
+            "absoluteRenderBounds": {
+              "x": 3266,
+              "y": 8803,
+              "width": 1200,
+              "height": 800
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:3705",
+            "name": "Error - Known error 1",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                }
+              ]
+            },
+            "explicitVariableModes": {
+              "VariableCollectionId:eadeca2af7463f0a0d10d1502f4ab1fb397e91a6/12:233": "12:3"
+            },
+            "children": [
+              {
+                "id": "202:3706",
+                "name": "Sidebar",
+                "type": "FRAME",
+                "locked": true,
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:65761f9cf0720fd19b5f1d45bec24418e47ec38c/463:163"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:65761f9cf0720fd19b5f1d45bec24418e47ec38c/463:163"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "itemSpacing": 71,
+                "layoutWrap": "WRAP",
+                "counterAxisSpacing": 0,
+                "counterAxisAlignContent": "AUTO",
+                "absoluteBoundingBox": {
+                  "x": 4638,
+                  "y": 7667,
+                  "width": 250,
+                  "height": 980
+                },
+                "absoluteRenderBounds": {
+                  "x": 4638,
+                  "y": 7667,
+                  "width": 250,
+                  "height": 980
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:3752",
+                "name": "Frame 334",
+                "type": "FRAME",
+                "locked": true,
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 4888,
+                  "y": 7667,
+                  "width": 950,
+                  "height": 979
+                },
+                "absoluteRenderBounds": {
+                  "x": 4888,
+                  "y": 7667,
+                  "width": 950,
+                  "height": 979
+                },
+                "constraints": {
+                  "vertical": "TOP_BOTTOM",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:3818",
+                "name": "Frame 392",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "absoluteBoundingBox": {
+                  "x": 4888,
+                  "y": 7707,
+                  "width": 950,
+                  "height": 587
+                },
+                "absoluteRenderBounds": {
+                  "x": 4888,
+                  "y": 7707,
+                  "width": 950,
+                  "height": 587
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/49:0"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "absoluteBoundingBox": {
+              "x": 4638,
+              "y": 7667,
+              "width": 1200,
+              "height": 980
+            },
+            "absoluteRenderBounds": {
+              "x": 4638,
+              "y": 7667,
+              "width": 1200,
+              "height": 980
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "exportSettings": [
+              {
+                "suffix": "",
+                "format": "JPG",
+                "constraint": {
+                  "type": "SCALE",
+                  "value": 1
+                }
+              }
+            ],
+            "effects": [],
+            "interactions": [
+              {
+                "trigger": {
+                  "type": "ON_CLICK"
+                },
+                "actions": [
+                  {
+                    "type": "NODE",
+                    "destinationId": null,
+                    "navigation": "NAVIGATE",
+                    "transition": null
+                  }
+                ]
+              }
+            ],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:8007",
+            "name": "Error modal",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                }
+              ]
+            },
+            "componentId": "207:37095",
+            "overrides": [],
+            "children": [
+              {
+                "id": "I202:8007;1252:53688",
+                "name": "Default",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                    }
+                  ]
+                },
+                "componentId": "207:37089",
+                "componentProperties": {
+                  "Show Addon panel#1319:3": {
+                    "type": "BOOLEAN",
+                    "value": true
+                  },
+                  "Show Sidebar#1319:2": {
+                    "type": "BOOLEAN",
+                    "value": true
+                  }
+                },
+                "overrides": [],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4764,
+                  "y": -2804,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": -4764,
+                  "y": -2804,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "I202:8007;1252:53689",
+                "name": "Modal",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
+                "paddingBottom": 10,
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4764,
+                  "y": -2804,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": -4764,
+                  "y": -2804,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP_BOTTOM",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutPositioning": "ABSOLUTE",
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [
+                  {
+                    "type": "BACKGROUND_BLUR",
+                    "visible": true,
+                    "radius": 24
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4764,
+              "y": -2804,
+              "width": 1260,
+              "height": 942
+            },
+            "absoluteRenderBounds": {
+              "x": -4764,
+              "y": -2804,
+              "width": 1260,
+              "height": 942
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:29298",
+            "name": "Annotation",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:7e2b5e2a4c7fb8c9a71c42bd93290d72833c7f8a/463:128"
+                }
+              ]
+            },
+            "componentId": "202:29282",
+            "componentProperties": {
+              "Show Author#10651:1": {
+                "type": "BOOLEAN",
+                "value": false
+              },
+              "Bright": {
+                "value": "false",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "I202:29298;960:6773",
+                "overriddenFields": [
+                  "characterStyleOverrides",
+                  "characters",
+                  "lineIndentations",
+                  "lineTypes",
+                  "styleOverrideTable"
+                ]
+              }
+            ],
+            "children": [
+              {
+                "id": "I202:29298;960:6773",
+                "name": "Content",
+                "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                    }
+                  ],
+                  "lineHeight": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:b89fb00006aaa5f4bb29c0e02e69d397c1a80074/12880:372"
+                    }
+                  ],
+                  "fontFamily": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:ed2bb38a99176e6f949bab649f230bf1b27c4383/12880:201"
+                    }
+                  ],
+                  "fontSize": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:4fdb23a8ab0d93e44c8440bc99f50840e14b004b/12880:127"
+                    }
+                  ],
+                  "fontStyle": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:96840dc5cfb7214fd0d7abbacfe02355db149df3/12880:237"
+                    }
+                  ]
+                },
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "absoluteBoundingBox": {
+                  "x": -4908,
+                  "y": -2249,
+                  "width": 208,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -4907.328125,
+                  "y": -2243.912109375,
+                  "width": 198.3779296875,
+                  "height": 32.55810546875
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "characters": "Do we still have a use case for showing the version issue here?",
+                "characterStyleOverrides": [],
+                "styleOverrideTable": {},
+                "lineTypes": [
+                  "NONE"
+                ],
+                "lineIndentations": [
+                  0
+                ],
+                "style": {
+                  "fontFamily": "Nunito Sans",
+                  "fontPostScriptName": "NunitoSans-Regular",
+                  "fontStyle": "Regular",
+                  "fontWeight": 400,
+                  "textAutoResize": "HEIGHT",
+                  "fontSize": 14,
+                  "textAlignHorizontal": "LEFT",
+                  "textAlignVertical": "TOP",
+                  "letterSpacing": 0,
+                  "lineHeightPx": 20,
+                  "lineHeightPercent": 104.73397827148438,
+                  "lineHeightPercentFontSize": 142.85714721679688,
+                  "lineHeightUnit": "PIXELS"
+                },
+                "layoutVersion": 4,
+                "styles": {
+                  "text": "202:29278"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "I202:29298;960:6774",
+                "name": "Author",
+                "visible": false,
+                "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
+                "componentPropertyReferences": {
+                  "visible": "Show Author#10651:1"
+                },
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:6e4d95574b46f0789280f5d7ddccb815d6fa47de/463:118"
+                    }
+                  ],
+                  "lineHeight": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:e955722fd41792f6cfb4fd428a9924a26ac1761a/12880:371"
+                    }
+                  ],
+                  "fontFamily": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:d9d449881d25410f40e5f24fa2331f18c653116a/12880:202"
+                    }
+                  ],
+                  "fontStyle": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:96840dc5cfb7214fd0d7abbacfe02355db149df3/12880:237"
+                    }
+                  ]
+                },
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9333333373069763,
+                      "g": 0.9529411792755127,
+                      "b": 0.9647058844566345,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:6e4d95574b46f0789280f5d7ddccb815d6fa47de/463:118"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "absoluteBoundingBox": {
+                  "x": -4908,
+                  "y": -2213,
+                  "width": 208,
+                  "height": 16
+                },
+                "absoluteRenderBounds": null,
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "characters": "Author",
+                "characterStyleOverrides": [],
+                "styleOverrideTable": {},
+                "lineTypes": [
+                  "NONE"
+                ],
+                "lineIndentations": [
+                  0
+                ],
+                "style": {
+                  "fontFamily": "SF Mono",
+                  "fontPostScriptName": "SFMono-Regular",
+                  "fontStyle": "Regular",
+                  "fontWeight": 400,
+                  "textAutoResize": "HEIGHT",
+                  "fontSize": 11,
+                  "textAlignHorizontal": "LEFT",
+                  "textAlignVertical": "TOP",
+                  "letterSpacing": 0,
+                  "lineHeightPx": 16,
+                  "lineHeightPercent": 121.8866195678711,
+                  "lineHeightPercentFontSize": 145.4545440673828,
+                  "lineHeightUnit": "PIXELS"
+                },
+                "layoutVersion": 4,
+                "styles": {
+                  "text": "202:29280"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18039216101169586,
+                  "g": 0.20392157137393951,
+                  "b": 0.21960784494876862,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:7e2b5e2a4c7fb8c9a71c42bd93290d72833c7f8a/463:128"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18039216101169586,
+                  "g": 0.20392157137393951,
+                  "b": 0.21960784494876862,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:7e2b5e2a4c7fb8c9a71c42bd93290d72833c7f8a/463:128"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.18039216101169586,
+              "g": 0.20392157137393951,
+              "b": 0.21960784494876862,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "paddingTop": 16,
+            "paddingBottom": 16,
+            "itemSpacing": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4924,
+              "y": -2265,
+              "width": 240,
+              "height": 72
+            },
+            "absoluteRenderBounds": {
+              "x": -4940,
+              "y": -2273,
+              "width": 272,
+              "height": 104
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.30000001192092896
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 8
+                },
+                "radius": 16,
+                "showShadowBehindNode": true
+              }
+            ],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:29299",
+            "name": "Pointer",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "componentId": "202:29292",
+            "componentProperties": {
+              "type": {
+                "value": "dot",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "202:29299",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [
+              {
+                "id": "I202:29299;960:6818",
+                "name": "Pointer",
+                "type": "VECTOR",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:d2055bc68302d5307121fe80438a09bbc1f5dd6c/463:143"
+                    }
+                  ]
+                },
+                "blendMode": "PASS_THROUGH",
+                "fills": [],
+                "fillOverrideTable": {
+                  "1": null
+                },
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.27843138575553894,
+                      "b": 0.5215686559677124,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d2055bc68302d5307121fe80438a09bbc1f5dd6c/463:143"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "strokeAlign": "CENTER",
+                "strokeDashes": [
+                  4,
+                  4
+                ],
+                "absoluteBoundingBox": {
+                  "x": -5018,
+                  "y": -2229,
+                  "width": 94,
+                  "height": 0
+                },
+                "absoluteRenderBounds": {
+                  "x": -5020.66650390625,
+                  "y": -2231.666748046875,
+                  "width": 96.66650390625,
+                  "height": 5.33349609375
+                },
+                "constraints": {
+                  "vertical": "SCALE",
+                  "horizontal": "SCALE"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": -5018,
+              "y": -2229,
+              "width": 94,
+              "height": 0
+            },
+            "absoluteRenderBounds": {
+              "x": -5020.66650390625,
+              "y": -2231.666748046875,
+              "width": 96.66650390625,
+              "height": 5.33349609375
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:29793",
+            "name": "Source",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                }
+              ]
+            },
+            "componentId": "202:29791",
+            "exposedInstances": [
+              "I202:29793;1318:23055"
+            ],
+            "overrides": [
+              {
+                "id": "I202:29793;1318:23055",
+                "overriddenFields": [
+                  "height",
+                  "primaryAxisSizingMode",
+                  "width"
+                ]
+              }
+            ],
+            "children": [
+              {
+                "id": "I202:29793;1318:23055",
+                "name": "_Source",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "componentId": "202:29786",
+                "isExposedInstance": true,
+                "componentProperties": {
+                  "Inverted": {
+                    "value": "true",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "I202:29793;1318:23055",
+                    "overriddenFields": [
+                      "height",
+                      "primaryAxisSizingMode",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "opacity": 0.8500000238418579,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.8500000238418579,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.8500000238418579
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "paddingLeft": 20,
+                "paddingRight": 5,
+                "paddingTop": 20,
+                "paddingBottom": 20,
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4892,
+                  "y": 62,
+                  "width": 800,
+                  "height": 120
+                },
+                "absoluteRenderBounds": {
+                  "x": -4892,
+                  "y": 62,
+                  "width": 800,
+                  "height": 120
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [
+              {
+                "opacity": 0.15000000596046448,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.14901961386203766,
+                  "g": 0.3333333432674408,
+                  "b": 0.45098039507865906,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "itemSpacing": 10,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4892,
+              "y": 62,
+              "width": 800,
+              "height": 120
+            },
+            "absoluteRenderBounds": {
+              "x": -4895,
+              "y": 60,
+              "width": 806,
+              "height": 126
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "202:29781"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:30868",
+            "name": "Source",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                }
+              ]
+            },
+            "componentId": "202:29791",
+            "exposedInstances": [
+              "I202:30868;1318:23055"
+            ],
+            "overrides": [
+              {
+                "id": "I202:30868;1318:23055",
+                "overriddenFields": [
+                  "height",
+                  "primaryAxisSizingMode",
+                  "width"
+                ]
+              }
+            ],
+            "children": [
+              {
+                "id": "I202:30868;1318:23055",
+                "name": "_Source",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "componentId": "202:29786",
+                "isExposedInstance": true,
+                "componentProperties": {
+                  "Inverted": {
+                    "value": "true",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "I202:30868;1318:23055",
+                    "overriddenFields": [
+                      "height",
+                      "primaryAxisSizingMode",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "opacity": 0.8500000238418579,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.8500000238418579,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.8500000238418579
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "paddingLeft": 20,
+                "paddingRight": 5,
+                "paddingTop": 20,
+                "paddingBottom": 20,
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4345,
+                  "y": 2262,
+                  "width": 800,
+                  "height": 120
+                },
+                "absoluteRenderBounds": {
+                  "x": -4345,
+                  "y": 2262,
+                  "width": 800,
+                  "height": 120
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [
+              {
+                "opacity": 0.15000000596046448,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.14901961386203766,
+                  "g": 0.3333333432674408,
+                  "b": 0.45098039507865906,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "itemSpacing": 10,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4345,
+              "y": 2262,
+              "width": 800,
+              "height": 120
+            },
+            "absoluteRenderBounds": {
+              "x": -4348,
+              "y": 2260,
+              "width": 806,
+              "height": 126
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "202:29781"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:30873",
+            "name": "const lightSyntaxColors = { green1: '#008000', red1: '#A31515', red2: '#9a050f', red3: '#800000', red4: '#ff0000', gray1: '#393A34', cyan1: '#36acaa', cyan2: '#2B91AF', blue1: '#0000ff', blue2: '#00009f', }; const darkSyntaxColors = { green1: '#7C7C7C', red1: '#92C379', red2: '#9a050f', red3: '#A8FF60', red4: '#96CBFE', gray1: '#EDEDED', cyan1: '#C6C5FE', cyan2: '#FFFFB6', blue1: '#B474DD', blue2: '#00009f', };",
+            "type": "TEXT",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:99bae1ca2ef70171da1df17ff2c1237fd6c6aa7e/986:71"
+                }
+              ],
+              "lineHeight": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:2f23a9e8650952f152e83705690925ada23af276/459:171"
+                }
+              ],
+              "fontFamily": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:68d54d1e74b8fc3713f444f0e363dbdaae65467e/459:217"
+                }
+              ],
+              "fontSize": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:711f85fd525d8f1a1eda4a22e7d6ac7e90e990bb/459:209"
+                }
+              ],
+              "fontStyle": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:51e951475fc4cf87b3e4f3ee9ca9d7a9e1730153/459:212"
+                }
+              ]
+            },
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18039216101169586,
+                  "g": 0.20392157137393951,
+                  "b": 0.21960784494876862,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:99bae1ca2ef70171da1df17ff2c1237fd6c6aa7e/986:71"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "absoluteBoundingBox": {
+              "x": -3345,
+              "y": 1847,
+              "width": 342,
+              "height": 520
+            },
+            "absoluteRenderBounds": {
+              "x": -3343.8193359375,
+              "y": 1871.6533203125,
+              "width": 214.25244140625,
+              "height": 492.46044921875
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "characters": "\nconst lightSyntaxColors = {\n  green1: '#008000',\n  red1: '#A31515',\n  red2: '#9a050f',\n  red3: '#800000',\n  red4: '#ff0000',\n  gray1: '#393A34',\n  cyan1: '#36acaa',\n  cyan2: '#2B91AF',\n  blue1: '#0000ff',\n  blue2: '#00009f',\n};\n\nconst darkSyntaxColors = {\n  green1: '#7C7C7C',\n  red1: '#92C379',\n  red2: '#9a050f',\n  red3: '#A8FF60',\n  red4: '#96CBFE',\n  gray1: '#EDEDED',\n  cyan1: '#C6C5FE',\n  cyan2: '#FFFFB6',\n  blue1: '#B474DD',\n  blue2: '#00009f',\n};",
+            "characterStyleOverrides": [],
+            "styleOverrideTable": {},
+            "lineTypes": [
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE",
+              "NONE"
+            ],
+            "lineIndentations": [
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0,
+              0
+            ],
+            "style": {
+              "fontFamily": "SF Mono",
+              "fontPostScriptName": "SFMono-Regular",
+              "fontStyle": "Regular",
+              "fontWeight": 400,
+              "textAutoResize": "HEIGHT",
+              "fontSize": 13,
+              "textAlignHorizontal": "LEFT",
+              "textAlignVertical": "TOP",
+              "letterSpacing": 0,
+              "lineHeightPx": 20,
+              "lineHeightPercent": 128.9185333251953,
+              "lineHeightPercentFontSize": 153.84616088867188,
+              "lineHeightUnit": "PIXELS"
+            },
+            "layoutVersion": 4,
+            "styles": {
+              "text": "202:7873"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:29807",
+            "name": "image 1",
+            "type": "RECTANGLE",
+            "scrollBehavior": "SCROLLS",
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "IMAGE",
+                "scaleMode": "FILL",
+                "imageRef": "c3226b139b72af28026f3c417e1fcd1d413778ca"
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -4892,
+              "y": 217,
+              "width": 1187,
+              "height": 262
+            },
+            "absoluteRenderBounds": {
+              "x": -4892,
+              "y": 217,
+              "width": 1187,
+              "height": 262
+            },
+            "preserveRatio": true,
+            "targetAspectRatio": {
+              "x": 2374,
+              "y": 524
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:30905",
+            "name": "Light theme syntax highight colors",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "202:30906",
+                "name": "Frame 311",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -3635,
+                  "y": 2671,
+                  "width": 580,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -3635,
+                  "y": 2671,
+                  "width": 580,
+                  "height": 40
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:30909",
+                "name": "Frame 315",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "itemSpacing": 30,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -3635,
+                  "y": 2711,
+                  "width": 580,
+                  "height": 540
+                },
+                "absoluteRenderBounds": {
+                  "x": -3635,
+                  "y": 2711,
+                  "width": 580,
+                  "height": 540
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.15000000596046448,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.14901961386203766,
+                  "g": 0.3333333432674408,
+                  "b": 0.45098039507865906,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "counterAxisAlignItems": "MAX",
+            "paddingLeft": 30,
+            "paddingRight": 30,
+            "paddingTop": 30,
+            "paddingBottom": 30,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -3665,
+              "y": 2641,
+              "width": 640,
+              "height": 640
+            },
+            "absoluteRenderBounds": {
+              "x": -3665,
+              "y": 2641,
+              "width": 640,
+              "height": 640
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:31218",
+            "name": "Dark theme syntax highight colors",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:7e2b5e2a4c7fb8c9a71c42bd93290d72833c7f8a/463:128"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                }
+              ]
+            },
+            "explicitVariableModes": {
+              "VariableCollectionId:a16f6f0391d628866e841b52a9137f44a3bd06cd/592:114": "105:0"
+            },
+            "children": [
+              {
+                "id": "202:31219",
+                "name": "Frame 311",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4315,
+                  "y": 2671,
+                  "width": 580,
+                  "height": 40
+                },
+                "absoluteRenderBounds": {
+                  "x": -4315,
+                  "y": 2671,
+                  "width": 580,
+                  "height": 40
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "202:31222",
+                "name": "Frame 315",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "itemSpacing": 30,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4315,
+                  "y": 2711,
+                  "width": 580,
+                  "height": 540
+                },
+                "absoluteRenderBounds": {
+                  "x": -4315,
+                  "y": 2711,
+                  "width": 580,
+                  "height": 540
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18039216101169586,
+                  "g": 0.20392157137393951,
+                  "b": 0.21960784494876862,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:7e2b5e2a4c7fb8c9a71c42bd93290d72833c7f8a/463:128"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18039216101169586,
+                  "g": 0.20392157137393951,
+                  "b": 0.21960784494876862,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:7e2b5e2a4c7fb8c9a71c42bd93290d72833c7f8a/463:128"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.18039216101169586,
+              "g": 0.20392157137393951,
+              "b": 0.21960784494876862,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "counterAxisAlignItems": "MAX",
+            "paddingLeft": 30,
+            "paddingRight": 30,
+            "paddingTop": 30,
+            "paddingBottom": 30,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4345,
+              "y": 2641,
+              "width": 640,
+              "height": 640
+            },
+            "absoluteRenderBounds": {
+              "x": -4345,
+              "y": 2641,
+              "width": 640,
+              "height": 640
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:31323",
+            "name": "Frame 654",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.4431372582912445,
+                  "g": 0.7843137383460999,
+                  "b": 0.9960784316062927,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.4431372582912445,
+                  "g": 0.7843137383460999,
+                  "b": 0.9960784316062927,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.4431372582912445,
+              "g": 0.7843137383460999,
+              "b": 0.9960784316062927,
+              "a": 1
+            },
+            "absoluteBoundingBox": {
+              "x": -4345,
+              "y": 2448,
+              "width": 136,
+              "height": 53
+            },
+            "absoluteRenderBounds": {
+              "x": -4345,
+              "y": 2448,
+              "width": 136,
+              "height": 53
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "202:31324",
+            "name": "Frame 655",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 0.4720000624656677,
+                  "b": 0.2800000011920929,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 0.4720000624656677,
+                  "b": 0.2800000011920929,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 0.4720000624656677,
+              "b": 0.2800000011920929,
+              "a": 1
+            },
+            "absoluteBoundingBox": {
+              "x": -4345,
+              "y": 2527,
+              "width": 136,
+              "height": 53
+            },
+            "absoluteRenderBounds": {
+              "x": -4345,
+              "y": 2527,
+              "width": 136,
+              "height": 53
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "207:48227",
+            "name": "image 4",
+            "type": "RECTANGLE",
+            "scrollBehavior": "SCROLLS",
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "IMAGE",
+                "scaleMode": "FILL",
+                "imageRef": "591b293e5024b69c149f6555ba8b4afcf9f067e3"
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -3504,
+              "y": 6456,
+              "width": 1371,
+              "height": 893
+            },
+            "absoluteRenderBounds": {
+              "x": -3504,
+              "y": 6456,
+              "width": 1371,
+              "height": 893
+            },
+            "preserveRatio": true,
+            "targetAspectRatio": {
+              "x": 2742,
+              "y": 1786
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:22028",
+            "name": "image 5",
+            "type": "RECTANGLE",
+            "scrollBehavior": "SCROLLS",
+            "blendMode": "PASS_THROUGH",
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "IMAGE",
+                "scaleMode": "FILL",
+                "imageRef": "26b0433b560883bb80c677edeafac24d3c10c5a5"
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -2084,
+              "y": -2804,
+              "width": 1099,
+              "height": 789
+            },
+            "absoluteRenderBounds": {
+              "x": -2084,
+              "y": -2804,
+              "width": 1099,
+              "height": 789
+            },
+            "preserveRatio": true,
+            "targetAspectRatio": {
+              "x": 2198,
+              "y": 1578
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:24260",
+            "name": "Docs",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "219:24261",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "219:24261",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I219:24261;1234:37381",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:24261;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:24261;1234:37441",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:24261;1234:37461",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  },
+                  {
+                    "id": "I219:24261;1234:37462",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -2165,
+                  "y": -1881,
+                  "width": 250,
+                  "height": 3574
+                },
+                "absoluteRenderBounds": {
+                  "x": -2165,
+                  "y": -1881,
+                  "width": 250,
+                  "height": 3574
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:24262",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -1915,
+                  "y": -1881,
+                  "width": 1010,
+                  "height": 3574
+                },
+                "absoluteRenderBounds": {
+                  "x": -1915,
+                  "y": -1881,
+                  "width": 1010,
+                  "height": 3574
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2165,
+              "y": -1881,
+              "width": 1260,
+              "height": 3574
+            },
+            "absoluteRenderBounds": {
+              "x": -2165,
+              "y": -1881,
+              "width": 1260,
+              "height": 3574
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:26873",
+            "name": "Docs error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "219:26874",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "219:26874",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I219:26874;1234:37381",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:26874;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:26874;1234:37441",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:26874;1234:37461",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  },
+                  {
+                    "id": "I219:26874;1234:37462",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -2165,
+                  "y": 1962,
+                  "width": 250,
+                  "height": 1729
+                },
+                "absoluteRenderBounds": {
+                  "x": -2165,
+                  "y": 1962,
+                  "width": 250,
+                  "height": 1729
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:26875",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -1915,
+                  "y": 1962,
+                  "width": 1010,
+                  "height": 1729
+                },
+                "absoluteRenderBounds": {
+                  "x": -1915,
+                  "y": 1962,
+                  "width": 1010,
+                  "height": 1729
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2165,
+              "y": 1962,
+              "width": 1260,
+              "height": 1729
+            },
+            "absoluteRenderBounds": {
+              "x": -2165,
+              "y": 1962,
+              "width": 1260,
+              "height": 1729
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:26786",
+            "name": "Preview",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                }
+              ]
+            },
+            "componentId": "219:22043",
+            "exposedInstances": [
+              "I219:26786;1316:28029",
+              "I219:26786;1316:28565",
+              "I219:26786;1318:40535"
+            ],
+            "componentProperties": {
+              "Show code#1318:0": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Show Toolbar#1316:7": {
+                "type": "BOOLEAN",
+                "value": false
+              }
+            },
+            "overrides": [
+              {
+                "id": "219:26786",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              },
+              {
+                "id": "I219:26786;1316:28029",
+                "overriddenFields": [
+                  "primaryAxisSizingMode"
+                ]
+              },
+              {
+                "id": "I219:26786;1318:23420",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [
+              {
+                "id": "I219:26786;1316:27450",
+                "name": "Toolbar",
+                "visible": false,
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "componentPropertyReferences": {
+                  "visible": "Show Toolbar#1316:7"
+                },
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                    }
+                  ]
+                },
+                "componentId": "207:29654",
+                "componentProperties": {
+                  "Show overflow menu#1334:3": {
+                    "type": "BOOLEAN",
+                    "value": false
+                  },
+                  "Show View addon panel button #1334:2": {
+                    "type": "BOOLEAN",
+                    "value": true
+                  },
+                  "Show sidebar button#1334:1": {
+                    "type": "BOOLEAN",
+                    "value": false
+                  },
+                  "Show tabs#1334:0": {
+                    "type": "BOOLEAN",
+                    "value": false
+                  },
+                  "Show rerun button#1334:7": {
+                    "type": "BOOLEAN",
+                    "value": false
+                  },
+                  "Type": {
+                    "value": "Preview",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 0,
+                  "bottom": 1,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "paddingRight": 10,
+                "itemSpacing": 24,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -855,
+                  "y": -466,
+                  "width": 800,
+                  "height": 40
+                },
+                "absoluteRenderBounds": null,
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "I219:26786;1318:30441",
+                "name": "Preview frame",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -855,
+                  "y": -466,
+                  "width": 930,
+                  "height": 96
+                },
+                "absoluteRenderBounds": {
+                  "x": -855,
+                  "y": -466,
+                  "width": 930,
+                  "height": 96
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "I219:26786;1318:23420",
+                "name": "_Source",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "componentPropertyReferences": {
+                  "visible": "Show code#1318:0"
+                },
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                    }
+                  ]
+                },
+                "componentId": "202:29785",
+                "componentProperties": {
+                  "Inverted": {
+                    "value": "false",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "I219:26786;1318:23420",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 20,
+                "paddingRight": 5,
+                "paddingTop": 20,
+                "paddingBottom": 20,
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -855,
+                  "y": -370,
+                  "width": 930,
+                  "height": 120
+                },
+                "absoluteRenderBounds": {
+                  "x": -855,
+                  "y": -370,
+                  "width": 930,
+                  "height": 120
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.15000000596046448,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.14901961386203766,
+                  "g": 0.3333333432674408,
+                  "b": 0.45098039507865906,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -855,
+              "y": -466,
+              "width": 930,
+              "height": 216
+            },
+            "absoluteRenderBounds": {
+              "x": -859,
+              "y": -469,
+              "width": 938,
+              "height": 224
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 1
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "202:29781"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:26037",
+            "name": "Docs",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "219:26038",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "219:26038",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I219:26038;1234:37381",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:26038;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:26038;1234:37441",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I219:26038;1234:37461",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  },
+                  {
+                    "id": "I219:26038;1234:37462",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 125,
+                  "y": -1881,
+                  "width": 250,
+                  "height": 1569
+                },
+                "absoluteRenderBounds": {
+                  "x": 125,
+                  "y": -1881,
+                  "width": 250,
+                  "height": 1569
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:26039",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 375,
+                  "y": -1881,
+                  "width": 1010,
+                  "height": 1569
+                },
+                "absoluteRenderBounds": {
+                  "x": 375,
+                  "y": -1881,
+                  "width": 1010,
+                  "height": 1569
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 125,
+              "y": -1881,
+              "width": 1260,
+              "height": 1569
+            },
+            "absoluteRenderBounds": {
+              "x": 125,
+              "y": -1881,
+              "width": 1260,
+              "height": 1569
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:25548",
+            "name": "Frame 394",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "219:25549",
+                "name": "FAIL |storybook (chromium)| src/stories/Button.stories.ts > Primary TypeError: Error is not a constructor ❯ Object.render [as originalStoryFn] src/stories/Button.stories.ts:57:16 55| 56| export const Primary = { 57| render: () => new Error('boom') | ^ 58| } 59| ❯ undecoratedStoryFn node_modules/storybook/dist/preview-api/index.js:2927:55",
+                "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:0b1282a74fa4977b19c45fc3629d767d12c8b7f4/463:109"
+                    }
+                  ],
+                  "lineHeight": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:2f23a9e8650952f152e83705690925ada23af276/459:171"
+                    }
+                  ],
+                  "fontFamily": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:68d54d1e74b8fc3713f444f0e363dbdaae65467e/459:217"
+                    }
+                  ],
+                  "fontSize": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:711f85fd525d8f1a1eda4a22e7d6ac7e90e990bb/459:209"
+                    }
+                  ],
+                  "fontStyle": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:51e951475fc4cf87b3e4f3ee9ca9d7a9e1730153/459:212"
+                    }
+                  ],
+                  "textRangeFills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:0b1282a74fa4977b19c45fc3629d767d12c8b7f4/463:109"
+                    }
+                  ]
+                },
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9254902005195618,
+                      "g": 0.95686274766922,
+                      "b": 0.9764705896377563,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:0b1282a74fa4977b19c45fc3629d767d12c8b7f4/463:109"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "absoluteBoundingBox": {
+                  "x": -859,
+                  "y": -1038,
+                  "width": 618,
+                  "height": 220
+                },
+                "absoluteRenderBounds": {
+                  "x": -858.3369750976562,
+                  "y": -1033.3466796875,
+                  "width": 616.2974243164062,
+                  "height": 212.796875
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "HUG",
+                "layoutSizingVertical": "HUG",
+                "characters": "FAIL  |storybook (chromium)| src/stories/Button.stories.ts > Primary\nTypeError:\nError is not a constructor\n❯ Object.render [as originalStoryFn] src/stories/Button.stories.ts:57:16\n     55|\n     56| export const Primary = {\n     57|   render: () => new Error('boom')\n       |                ^\n     58| }\n     59|\n❯ undecoratedStoryFn node_modules/storybook/dist/preview-api/index.js:2927:55",
+                "characterStyleOverrides": [
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  20,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  21,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  20,
+                  20,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  20,
+                  20,
+                  0,
+                  0,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  28,
+                  0,
+                  26,
+                  26,
+                  26,
+                  26,
+                  26,
+                  26,
+                  26,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  20,
+                  20,
+                  0,
+                  0,
+                  0,
+                  0,
+                  24,
+                  24,
+                  24,
+                  24,
+                  24,
+                  24,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  28,
+                  28,
+                  28,
+                  0,
+                  89,
+                  89,
+                  89,
+                  89,
+                  89,
+                  0,
+                  0,
+                  31,
+                  31,
+                  31,
+                  31,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  20,
+                  20,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  20,
+                  20,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  20,
+                  20
+                ],
+                "styleOverrideTable": {
+                  "20": {
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 0.4720000624656677,
+                          "b": 0.2800000011920929,
+                          "a": 1
+                        }
+                      }
+                    ]
+                  },
+                  "21": {
+                    "fontFamily": "SF Mono",
+                    "fontPostScriptName": "SFMono-Regular",
+                    "fontStyle": "Regular",
+                    "fontWeight": 400,
+                    "textAutoResize": "WIDTH_AND_HEIGHT",
+                    "fontSize": 13,
+                    "letterSpacing": 0,
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9254902005195618,
+                          "g": 0.95686274766922,
+                          "b": 0.9764705896377563,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:0b1282a74fa4977b19c45fc3629d767d12c8b7f4/463:109"
+                          }
+                        }
+                      }
+                    ],
+                    "lineHeightPx": 20,
+                    "lineHeightPercent": 128.9185333251953,
+                    "lineHeightPercentFontSize": 153.84616088867188,
+                    "lineHeightUnit": "PIXELS",
+                    "inheritTextStyleId": "202:7873",
+                    "boundVariables": {
+                      "lineHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:2f23a9e8650952f152e83705690925ada23af276/459:171"
+                      },
+                      "fontFamily": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:68d54d1e74b8fc3713f444f0e363dbdaae65467e/459:217"
+                      },
+                      "fontSize": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:711f85fd525d8f1a1eda4a22e7d6ac7e90e990bb/459:209"
+                      },
+                      "fontStyle": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:51e951475fc4cf87b3e4f3ee9ca9d7a9e1730153/459:212"
+                      }
+                    }
+                  },
+                  "24": {
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.5882353186607361,
+                          "g": 0.7960784435272217,
+                          "b": 0.9960784316062927,
+                          "a": 1
+                        }
+                      }
+                    ]
+                  },
+                  "26": {
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 0.7137255072593689,
+                          "a": 1
+                        }
+                      }
+                    ]
+                  },
+                  "28": {
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.7764706015586853,
+                          "g": 0.772549033164978,
+                          "b": 0.9960784316062927,
+                          "a": 1
+                        }
+                      }
+                    ]
+                  },
+                  "31": {
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.7572254538536072,
+                          "g": 0.5500578284263611,
+                          "b": 0.8899422287940979,
+                          "a": 1
+                        }
+                      }
+                    ]
+                  },
+                  "89": {
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9787607789039612,
+                          "g": 0.4158080220222473,
+                          "b": 0.5659287571907043,
+                          "a": 1
+                        }
+                      }
+                    ]
+                  }
+                },
+                "lineTypes": [
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE",
+                  "NONE"
+                ],
+                "lineIndentations": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ],
+                "style": {
+                  "fontFamily": "SF Mono",
+                  "fontPostScriptName": "SFMono-Regular",
+                  "fontStyle": "Regular",
+                  "fontWeight": 400,
+                  "textAutoResize": "WIDTH_AND_HEIGHT",
+                  "fontSize": 13,
+                  "textAlignHorizontal": "LEFT",
+                  "textAlignVertical": "TOP",
+                  "letterSpacing": 0,
+                  "lineHeightPx": 20,
+                  "lineHeightPercent": 128.9185333251953,
+                  "lineHeightPercentFontSize": 153.84616088867188,
+                  "lineHeightUnit": "PIXELS"
+                },
+                "layoutVersion": 4,
+                "styles": {
+                  "text": "202:7873"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.1417643278837204,
+                  "g": 0.1417643278837204,
+                  "b": 0.1417643278837204,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.1417643278837204,
+                  "g": 0.1417643278837204,
+                  "b": 0.1417643278837204,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.1417643278837204,
+              "g": 0.1417643278837204,
+              "b": 0.1417643278837204,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 12,
+            "paddingBottom": 12,
+            "itemSpacing": 10,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -871,
+              "y": -1050,
+              "width": 962,
+              "height": 244
+            },
+            "absoluteRenderBounds": {
+              "x": -871,
+              "y": -1050,
+              "width": 962,
+              "height": 244
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:31361",
+            "name": "Error modal",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "219:31362",
+                "name": "Default",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                    }
+                  ]
+                },
+                "componentId": "207:37089",
+                "componentProperties": {
+                  "Show Addon panel#1319:3": {
+                    "type": "BOOLEAN",
+                    "value": true
+                  },
+                  "Show Sidebar#1319:2": {
+                    "type": "BOOLEAN",
+                    "value": true
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "219:31362",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8435;1001:9456",
+                    "overriddenFields": [
+                      "primaryAxisSizingMode"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8436;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8438;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8440;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8441;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8442;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8443;988:9481;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8444;988:9481;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8445;988:9481;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8446;988:9481;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8447;988:9481;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8448;988:9526;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8449;988:9526;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8450;988:9540;993:8029;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8451;988:9526;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8452;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8453;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8454;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8456;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8457;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8458;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8459;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8460;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8461;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8462;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8463;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1002:8464;988:7229;988:7130;1203:14411",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1248:28294;1233:14265;1212:12829",
+                    "overriddenFields": [
+                      "primaryAxisSizingMode"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1248:28294;1233:14266;1212:12829",
+                    "overriddenFields": [
+                      "primaryAxisSizingMode"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1248:28294;1233:14267;1212:12829",
+                    "overriddenFields": [
+                      "primaryAxisSizingMode"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13396;1248:28294;1233:14269;1204:20146;1204:18751;1203:14412",
+                    "overriddenFields": [
+                      "layoutGrow",
+                      "textAutoResize"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13398;1003:10954",
+                    "overriddenFields": [
+                      "primaryAxisSizingMode"
+                    ]
+                  },
+                  {
+                    "id": "I219:31362;1003:13398;1003:11022",
+                    "overriddenFields": [
+                      "primaryAxisSizingMode"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4764,
+                  "y": -1152,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": -4764,
+                  "y": -1152,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:31363",
+                "name": "Modal",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
+                "paddingBottom": 10,
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -4764,
+                  "y": -1152,
+                  "width": 1260,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": -4764,
+                  "y": -1152,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP_BOTTOM",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutPositioning": "ABSOLUTE",
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [
+                  {
+                    "type": "BACKGROUND_BLUR",
+                    "visible": true,
+                    "radius": 24
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:825feba20b09b22e870fc1caa20e0a4f79f7588f/463:122"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4764,
+              "y": -1152,
+              "width": 1260,
+              "height": 942
+            },
+            "absoluteRenderBounds": {
+              "x": -4764,
+              "y": -1152,
+              "width": 1260,
+              "height": 942
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "219:36636",
+            "name": "Story",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "219:36637",
+                "name": "Frame 656",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "itemSpacing": 8,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -821,
+                  "y": 953,
+                  "width": 930,
+                  "height": 24
+                },
+                "absoluteRenderBounds": {
+                  "x": -821,
+                  "y": 953,
+                  "width": 930,
+                  "height": 24
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "219:36640",
+                "name": "Preview",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                    }
+                  ]
+                },
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.15000000596046448,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.14901961386203766,
+                      "g": 0.3333333432674408,
+                      "b": 0.45098039507865906,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                      }
+                    }
+                  }
+                ],
+                "cornerRadius": 4,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "strokesIncludedInLayout": true,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -821,
+                  "y": 993,
+                  "width": 930,
+                  "height": 400
+                },
+                "absoluteRenderBounds": {
+                  "x": -825,
+                  "y": 990,
+                  "width": 938,
+                  "height": 408
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "HUG",
+                "effects": [
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 1
+                    },
+                    "radius": 3,
+                    "showShadowBehindNode": false
+                  }
+                ],
+                "styles": {
+                  "effect": "202:29781"
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "itemSpacing": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -821,
+              "y": 953,
+              "width": 930,
+              "height": 440
+            },
+            "absoluteRenderBounds": {
+              "x": -825,
+              "y": 953,
+              "width": 938,
+              "height": 445
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "296:27843",
+            "name": "405",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "296:27844",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "296:27844",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I296:27844;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties",
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -2343,
+                  "y": 10197,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -2343,
+                  "y": 10197,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "296:27845",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -2093,
+                  "y": 10197,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -2093,
+                  "y": 10197,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2343,
+              "y": 10197,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2343,
+              "y": 10197,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "296:27849",
+            "name": "Docs error",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "296:27850",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                    }
+                  ]
+                },
+                "componentId": "207:29422",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "296:27850",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  },
+                  {
+                    "id": "I296:27850;1234:37381",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I296:27850;1234:37419",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I296:27850;1234:37441",
+                    "overriddenFields": [
+                      "componentProperties"
+                    ]
+                  },
+                  {
+                    "id": "I296:27850;1234:37461",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  },
+                  {
+                    "id": "I296:27850;1234:37462",
+                    "overriddenFields": [
+                      "visible"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:264d1eb130625a8449defca4a602b2870862da72/985:2"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "opacity": 0.10000000149011612,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/986:26"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -983,
+                  "y": 10197,
+                  "width": 250,
+                  "height": 1729
+                },
+                "absoluteRenderBounds": {
+                  "x": -983,
+                  "y": 10197,
+                  "width": 250,
+                  "height": 1729
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "296:27851",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -733,
+                  "y": 10197,
+                  "width": 1010,
+                  "height": 1729
+                },
+                "absoluteRenderBounds": {
+                  "x": -733,
+                  "y": 10197,
+                  "width": 1010,
+                  "height": 1729
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/463:68"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -983,
+              "y": 10197,
+              "width": 1260,
+              "height": 1729
+            },
+            "absoluteRenderBounds": {
+              "x": -983,
+              "y": 10197,
+              "width": 1260,
+              "height": 1729
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": "202:4272",
+        "flowStartingPoints": [
+          {
+            "nodeId": "202:4272",
+            "name": "Error message"
+          },
+          {
+            "nodeId": "202:3705",
+            "name": "Milestone 2 - Error"
+          }
+        ],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "209:21359",
+        "name": "Components",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "209:21366",
+            "name": "Render fail",
+            "type": "COMPONENT",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "209:21361",
+                "name": "Badge",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:d798459f360bdd2e767346fda60bae621c63bd07/986:59"
+                    }
+                  ]
+                },
+                "componentId": "202:4563",
+                "componentProperties": {
+                  "Label#1035:71": {
+                    "type": "TEXT",
+                    "value": "Error"
+                  },
+                  "Icon#1035:58": {
+                    "type": "INSTANCE_SWAP",
+                    "value": "202:4531",
+                    "preferredValues": [
+                      {
+                        "type": "COMPONENT",
+                        "key": "cde6e99610fe23f5f6e899466055a8bcf67e9fe8"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "df9ff32a87362484604f96eb5040bb326e7cebee"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "bc9c3ce5dee1a06019af3e859679c6c78a3e3fc3"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "dcd232117833a43011a5edf604bb854daba5e8d5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2b22c60a7a9fcf87bfd10b06696320306571c3bb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "7bcf129277361411a22355c78669ed4ddb10d61d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "7dfb5b9b30b050fadf78eef3da672ebbfb5a0724"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3c30efba40b19326ff5aa1ef845c5196d6ea5d44"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "65283ba2f226339cc1ff62b1c5aa53aff1d26675"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "4ee21d1235733a0c4dd5ce86863c835193e87e08"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b3e73a8576cdd4ab000938fe92140c7c46ac4898"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1f2f52ed14421b542ba355a68eefb342c4fc8609"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f20d97fa53461e70fa4cf38847381e32969958bd"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1d4c8aa42182274114dc383b1fac30770e4f4b1b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1f0babbbe489db971907ffe9e773d870c91c8658"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "d1f58f12143cf4fa2e71b76a492bfabdf1ec26b8"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f5efcf3fd172c0edfea03749ce439391388af543"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a392a346c0d75541003df4e5a7ccf7a522661e19"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "575ce569a30711eda32c4f39214d58676ceafbc2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b99921ef1c1c74c80e6aba135cd569e5079e369b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "69dcd51e761b6c016dfcbd970f0a1069fb4232e5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "52b49fdefd66e410a0e90c4afcffb2e4ee8a3fcd"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "18ef7d2d83d0a82f66146368afe2069354346582"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f2998e8d1b029b6dadb8ff16591673844c27aad4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f9792b0878248f7c7cb9cb28083580343a5d6ad7"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b08d30540768ece3a31bcfbea68c2be5b43bfdd8"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5355d8bbed12105190a1afd23036095aa62d89f4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "7d7e1055248fc992c0c0028489cf095930c7d97b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a28d58b5611ff58c7ce9a5634c017bf07a4f943a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1d2027fe87d1197461853df6b0488477067ad45b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "67f27846526c954a14316e639f6e2e5ff3e08119"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "edfe7db481416949757a061b7a8f65950330efc4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "44a7015592ab92c8ac73b6f8b863947260cbb146"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b04e0d2b2c1847fa2c9a40aa476056668ed0bbdb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "369442d07b722f98e9adc8ade15534042abcc592"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ff5600127f5aa63e0bf5dc76ab2b45688f5372f4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "18b4e093cb2ac5827f47d8866e5b47d7ff1d1ab2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "abf96b2578a614b9d1c813684950c79a5c8314e5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "e9284b745f15e00bc52ac7616271d408e695036a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "768e9615468a801a6e5468289e4b99e7b2e52b59"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c78e305cd4c27d7040bd818178534e2992ed8845"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "49c2b6170bb1b41737aa6d1cd2d23734c1370079"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "16274c6658f388f7d8c15ec2e031042f30e24a10"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "07ddaf86b9c60b319d448d5224073184b720c71d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "6913112844237795ef31fc67164cda1c27497e54"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "eb6a551f1a5b935502d7b8931ece188a5229e3a4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "52abeaa13909e713e4ac4aaa6a00c670f0348b2b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c28b39b8683c873542040e361846b42c25177cf6"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1e3c7368ae643a7fc2cefd1c9f8fd3535912d993"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "584472d87f105a9c7833b4808413486f8aafac71"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8e6d10de483cfb72bcfa5278b8c2c1ebe2e1a255"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ed2daac823a295d3047be98e2cc0f6989e242ea1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9b1a338cddc68f6c2b2fe90693b4e002d4b54fae"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "65b7e4633d87d14da71326a86d2d16ee6b8d162d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "6efe434945c50e1396f98e717613654a8a0c072b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8025f7e71088f9e7b74df9879aa9c240d5ed7c22"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c0ec4808a97bd02b68d585df8fd3ed7cc60c9096"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2d3766b1be21b75452d5bb3f6f35c3ae47d546cd"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "47eb4b984c6fc80da8d2b6b2fccc0299a943f3a9"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "02c7925f93588d6c5b4429b2d3d0231ea57e2a82"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "906acaf7b991a6df0142d3d4e0b72049c3ab1175"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8701177f4e8ca335182dd7566c37b0e71d6b0cd5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "deac648a45ce880449da9f8eb5b8a76b7beac84b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "187f51bba4d68a57893b0d31c79d65efa543554d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f51e78a95dfb6e02c1dcedaf9434f8cb026f8d48"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9127fd840d9d6ccd5733ef82340dd62560dfe332"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ee72cf24f225f178b58785cdd002160db88ec9c5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "7e5bbdf5dcc69ad06b78cc44609c752d9d251a0c"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8875d59e01838425a7b74309dd58c07a4beb49b7"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "855d3c45ecfee95fbd88e27c50e1723eaaa61d88"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "18668572262f9da7335cd40f61c82f54667e9be2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "71a9eaae9c1a7e8948fbdc0cb7fd4cf0860c01c4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9bfe5e4a5a1091b38eed4e36f619448f58cd77c4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "dad34b3dde7098709a5983e2430d315ab62bafd7"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "d7375122322b48827284dd163b4956a17f16abe2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5bd303aa48e7b6765bbc076131ed10c7da3199b2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8a5d9cfcf7b4c54931bfee64321cbb1b4a2ff765"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "264f5d7406bff589f0f522a29e4d500b7ce7ed15"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0b6c4192fb5646c4b7a0b51c38ce2835a822a903"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "78d860ed41b0b86ec927f496cfffa9fdd4aa72da"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f6168ef13ed08ee603c637105c77f856c3241542"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "6e1af80816696ad33b6841e3499af15bc60b07c6"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "35f0ffb3fbb4d3e02915f54b767e312c474f4a7d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c064d01118d50bbc15eb5603ba4093922affc793"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0113cb38118c08cca9148088102e94c3a6d2f763"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "924c523b2696861a938d6426bc80280411846dff"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "afb017524a8df47e6ff9738891327555c88d7799"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2f743afc00a9d5d050c7045229152d91591446ce"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5854520ada5e33f855d9199eeead5c108cf08b7a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "52ab7be13288aa7ecacae45875dbc66d50681388"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c085423ff2914bcaf58ce5d3aa7f60dc56807add"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "598e12a1e9b0c0ef952a6a319516c9c70e33b10a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "fcfeb2a26c7c348bc525f945b04080ed33432585"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "625d050b088fa6cadbda4decde09c7da126dc586"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "05d0708cf435a964bdba8439e7635215993255ec"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9eaa2d681e89375187b058dfc2392be113b345c8"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "df26931b6e9274fb968d22498fe92d263221f0da"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b683d9937d23db87c6c7117dd3fdc4110cb4508a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "df9cba55a118a8ff2259715d71da575bfe51655d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f37c1a1f4ab66813963d250240dd00e302941fe0"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "01786bf660e8cab339b4f1d326ee05dd707389d0"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "e76e872660912f741119e4912bbdf7fb03b4a0e1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0ef9970cfa7d05522ae22a03f156ec95b604055b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c1ab86e4cdd35bd47a52ea6fc126a488c4d5fb54"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "44469809fc3d212dc2a94be02d77e3c1b36ba700"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b4e117b29f892ec4be2fc62b60555d2fd6e2dcd3"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ebfaa9312b4635ca2745d0663de36821692ed000"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ef3a9c7dac3685cf962a5fce73c942dc2aaeddbe"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "debe0a5b2577563070203dee930c2a75cfbf9b54"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "149e90dc14c030048e14aa826ed7ccf28046287a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "cb3b40439cd65303dd78c89636b3ce6f536a7dfa"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3f8b7ec915586312fdc4ad79eebc610584b1c65a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1c240829f3a568ebffdb2d6bd0b06edc5aebad38"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a9e72688cd0c495ad0ae21cb3bd66b9b5ff0e93b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0a351bb253736c9d6c0adcf6d368ea995bdb5d75"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "98a9cc9e57ae6b39be4c13e301685c3d91812908"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0d66d5444492bef89094a7aa318d545170693a7a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "99ad01e810ea0e668f87e9e2ba8929e69485504d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3e2fa94e14350ca81af4bc42da8ceaf83a16e390"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "dd04a64cf1b76b4b50999109f3c2ee4b3405d4a1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "411dcdba908a353995ab4e6c1242711f4e969770"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8031d12d2e6cf86e7d6b250dc8a34bd3676f2f67"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "871621a0c2d896fbfa9c3c357776930a7d65cc0f"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "70ad98b7706acedbf78ef80c966c382326d71eb5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9c5c0569c1ab6546a7e172310ec027a6d14d66c0"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a8a3ab6452acda7547d3c4b5ffcde938989825f7"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "04eeac68e8f31bc54ce7812b0116f1f30e625240"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ab0294fc4ac99014826f83cd4f0a43b0e5eceedb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "e087f97e1c24585fc57944511cfb4b4783935323"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "efdb40974a70ee4c41a87c868ad4f7aeb244152d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "48490a81e142a1f869a4b650fa162d2d3bb11773"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c3866e8449fa95018c5c9b5aa00e8287841e702d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "347a8ada573f5f8bc7f402988c1ecefb5c28cadf"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "35e369a23e5a6fe9b765ab1d0ca27633405ccf63"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "1da37329b2fe90fb0da3190c72f0ef4499d2bec9"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "00ef6252e696625f09ae4c3066ed7e43a83cd616"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c928c48026be97b5b340ce9291e5e6c05240a2bd"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a6be3b6a80b805b570768d56b99c1d4358204b5b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "41698459d50dbee8284bbf2c68a827daaf62c35d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b8c4ecf7b2a4864356b580d7a8dd383510dd1ebb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "16e77449e47eba397a4e454d265585e99e94a927"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ced85e18c141c19a394f0ff2ee0e59daee679bf6"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "08f223960dd2ab48b88769642f4b04e8cc2b7158"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8bd5c749411d8f657513d0b8250fea4c18b64c48"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "4cf126462d4360c0016dbcfc69c99c30277358d2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2bd0084b9b7692222c7ca705e6c894ba984d081a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b69f90a87fa14e9f8c2a6aa0e6d3542b677fcbb1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "41a325e0f3169fec18465175035771da9ad86e94"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "cbff1216e00b579dbf8c9c7a6d58a91ca8e2fe2e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3c4307f3b06b214f86dcd9a2020dbb683ffe9d17"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "70ba7fed185f7f6b41e0af5adcfcf8b5514ff4ac"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a5675058d14dc8212682857a5e4c7dc6d9fa5a3a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "75521ef9e92d5f8b2f723a2d6ea24d0a938c1d93"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "41506c900113e39540af4813fed5c2042fe8d7e6"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "4ab6245f045353eb17a8e52950882b3f4c7c7ebb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3eebb11166358261a7c55d1b75f3b42bfc859080"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8491e103a72434357e7992ce3904d59759633580"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b44bc26592cbb20c785a20289e72c76c991effd4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5755f1ae5e03716afc369d2599c07706d9d083d5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "d76842417c472cd1a23783101bea7835c4121c73"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0e55cbafe970c4cdae0f113de89170ac1523daff"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "55b49abe140d3345413157cd9184368d88a106e1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "04642eeb7db49616b11693e1a6af26fa0b19547e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "727a99d5692df2504964a9edcad60d6ce89624f4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3c97b2c019ece2973718a7e160940a014c0e5c01"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "742478f3eb5a6d9088e0968cfec024cc9e1aa4dd"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b7da99201a94a9c4abb939099fe34c0b485f2fe9"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "28be07a09951fc32072bd9ce49c774c038ebc9f9"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ce138965d82285f9a7badc1ecd622cfaa46e29d5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "164de21bdb23d1544c0eaee3aabd1330041e6a07"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "30557d8dc867897af7366948597e1873df683bef"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "6a4a641540b5680278f49d678db21481d06329eb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "638416f4623c2bba7a5900d4e4e5a0cce205f78b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "dd250bed42c79c7efb32cc7b4034c5bea2f54122"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "d79c3a9bd265d7e90b4f0a531c64caae83f92cf4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f1253a09cc02e0c5935ae5a81d8ac31b27a5da5e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5faa25ee8cdbaa21014f53147aedb93cca8ebef1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0f846b307aeb0a1256e81548eaed3a60ece8b425"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5d3708c73fe56c0765f1edf5ad878c1ce5fb7dd0"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8586f64eba1c595ff2553e09f421226853b4b12c"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "4e8a334841f26af155a2e4a41a96fb1842a737f3"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a76f793e755d216cb9fcc3926db5070809de6836"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "db9439690a8706ec8e2d84c9655500c4782c6e74"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2f6bc6d7a2ea2afbfb246bbf5185acb5d24320aa"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "17cdf2787f570946dd2f841a10608851f664049e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9874173874a14dc308d13f8e532ca209852443a0"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "deff16aa582f03c9445574e3bd8da458068f2d6c"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "cf76113b988f386daa9d3ab32cbcd217ba2af479"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "beedd3b5f1afeaf25cdb467696e5e31106916303"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f4fc786e74bad64cea1c1d1e67d7e0f00e6aa01b"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3cde6a8bd7d52df24705eb1d75927f18cc172cef"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "82767fbab3a3bd6255987c0fa9739b4796e643d7"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "598757d04fb96caadf0c2af6743d9c2e51c13740"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "6932a4e56e4f40efdf83e151ac9c78d33d766b3c"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5dbe33fea3e39eb9c44a686980405e6e5545fc7e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "795ef2f36fd554aba49ee3d81dca71e5505a08a1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "dadba390123caf0130dbab40c0e84d1fb26fb036"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "5a81f80bf64678cbb544b3fb63c1d05b9dcd04f1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "4e679b3d2f5428a05449090345311b50382dde80"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "417c9322e14ee4d835e39f0edcebd18ebb3abdde"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ad1603486627a868f05b80f671d2fd5a42571370"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "7f7a51641430f5f7b60a0a19a4bd0649efba1711"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b87ac90b6b74602a38aa748baeffdc1701ce725e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "29cd127c49deb9bdc043824a5909e6355136a1d4"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2f97f880848e102245679ee524502215f7bbe351"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "8932e88ff152fa15bc85de82a155ff15686b4310"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "372377faf44700cd40f2950c87b2c12dc828a925"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "bae6126d09be64b4b1a997cc7c243233b7370818"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "02c81e2130ee6feae808519e400a303dc2e75145"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "938f779f709822345be50a32c906093b6c7ddd79"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f42687bc78343cef87e0157e73e3f2873ace7433"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "796e621b773949cad33a4e44e10daaeee95e52d5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "cb3fb9db070d128b797fcfa3f2b1257187608a68"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "722eee10732a0786f499e87d40e95581dbc96af2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b48375028aaf9f26d20e53fea24764c3d1665f2e"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "cbb0131ef374b8fedb90982f40bbc5b6899d61f5"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "81c9c7e6dae405d4592d9cc1d6790b9cf66462ec"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c817a37a99edf273f2382490139dfac699e919a6"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "6d43b51a5c70c9a9e8bcf15cc9e1eadfa61d84ef"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "2eaf3e1664b397d25a9090b063afcc3140dfb9f2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "f8a0944fce699453d6b4d4618eb3025bd9b41625"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "e010695174aa895038d2e5186316d984b4065b82"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "aeeaa0ac06b12b30a9fe15cc984c1ba704607bfb"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "21df61aa938c07615603bdc8e0427fac7ce265d1"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "ab50792edf3de221c89f8e0a98b0bbd53e0d3c95"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b6c714d1c24cb09fe40ff63b3bb002e1924a2f1a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "987639e3f5b82176ad355fccdb72d605dddd8e73"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "9b5e344f2945edaad3344f4a364853f8b2d50581"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "7ad9d1dcd58a434c982a324b9f10dfa6feb07c32"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "10a0b4e8be16eb5aeb892a57735752d87df06f5a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "aefe3b53c34106cb11c4fd97726ad1261135023d"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a56d0cac139796f0fe5c41509ce8006458a94c98"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "bd772484638038c105840e69d508678d396bc76a"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "0fd3e0ecc3e02d2b695ddad76bd940a3bc4518c3"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "856d21902b9b2a6e6ac37e8228676d0590f0c007"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "cfce3aa6bcf6e68e6ec84bcdb0369bb9f829d6b2"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "a90c64ab658a57a9b5f45f37063928b3db8d80b8"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "c0f847df17411c6ae969d2bd23b5025f7a699dde"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "3a9789a3101c06b49acf0042b3ce55e5e5c26d11"
+                      },
+                      {
+                        "type": "COMPONENT",
+                        "key": "b73a22e0a20ae8cf32e67eea25968ff634ad764f"
+                      }
+                    ]
+                  },
+                  "Show Icon#1035:45": {
+                    "type": "BOOLEAN",
+                    "value": false
+                  },
+                  "Type": {
+                    "value": "Critical",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  },
+                  "Compact": {
+                    "value": "false",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.2666666805744171,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d798459f360bdd2e767346fda60bae621c63bd07/986:59"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.2666666805744171,
+                      "b": 0,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d798459f360bdd2e767346fda60bae621c63bd07/986:59"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "cornerRadius": 30,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 0.2666666805744171,
+                  "b": 0,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 2,
+                "paddingBottom": 2,
+                "itemSpacing": 4,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 53,
+                  "height": 20
+                },
+                "absoluteRenderBounds": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 53,
+                  "height": 20
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "HUG",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "209:21362",
+                "name": "Component failed to render",
+                "type": "TEXT",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:99bae1ca2ef70171da1df17ff2c1237fd6c6aa7e/986:71"
+                    }
+                  ],
+                  "lineHeight": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:2f23a9e8650952f152e83705690925ada23af276/459:171"
+                    }
+                  ],
+                  "fontFamily": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:327ca9e7a84f3a4e62684315868d1bfd837f0908/459:216"
+                    }
+                  ],
+                  "fontSize": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:cb08118d4348ee485fe8d66c3b53569ac1af7d5d/459:163"
+                    }
+                  ],
+                  "fontStyle": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:9d3ba3e67176f38a3a8af83d2061c1690ab8d42d/459:213"
+                    }
+                  ]
+                },
+                "blendMode": "PASS_THROUGH",
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.18039216101169586,
+                      "g": 0.20392157137393951,
+                      "b": 0.21960784494876862,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:99bae1ca2ef70171da1df17ff2c1237fd6c6aa7e/986:71"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "absoluteBoundingBox": {
+                  "x": 61,
+                  "y": 0,
+                  "width": 180,
+                  "height": 20
+                },
+                "absoluteRenderBounds": {
+                  "x": 61.75600051879883,
+                  "y": 4.97599983215332,
+                  "width": 178.28114318847656,
+                  "height": 12.544000625610352
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "HUG",
+                "layoutSizingVertical": "HUG",
+                "characters": "Component failed to render",
+                "characterStyleOverrides": [],
+                "styleOverrideTable": {},
+                "lineTypes": [
+                  "NONE"
+                ],
+                "lineIndentations": [
+                  0
+                ],
+                "style": {
+                  "fontFamily": "Nunito Sans",
+                  "fontPostScriptName": "NunitoSans-Bold",
+                  "fontStyle": "Bold",
+                  "fontWeight": 700,
+                  "textAutoResize": "WIDTH_AND_HEIGHT",
+                  "fontSize": 14,
+                  "textAlignHorizontal": "LEFT",
+                  "textAlignVertical": "TOP",
+                  "letterSpacing": 0,
+                  "lineHeightPx": 20,
+                  "lineHeightPercent": 104.73397827148438,
+                  "lineHeightPercentFontSize": 142.85714721679688,
+                  "lineHeightUnit": "PIXELS"
+                },
+                "layoutVersion": 4,
+                "styles": {
+                  "text": "202:5191"
+                },
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisAlignItems": "CENTER",
+            "itemSpacing": 8,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 241,
+              "height": 20
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 241,
+              "height": 20
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "207:49401",
+        "name": "Thumbnail",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "208:20387",
+            "name": "Thumbnail",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "208:20388",
+                "name": "Thumbnail",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:e8c4c30dbd720aa292e1b366176b5c081d18fd59/10588:695"
+                    }
+                  ]
+                },
+                "componentId": "208:20361",
+                "exposedInstances": [
+                  "I208:20388;2:261"
+                ],
+                "componentProperties": {
+                  "Icon#2:8": {
+                    "type": "INSTANCE_SWAP",
+                    "value": "208:20326",
+                    "preferredValues": []
+                  },
+                  "Description#2:4": {
+                    "type": "TEXT",
+                    "value": "Render errors and 404s"
+                  },
+                  "Title#2:0": {
+                    "type": "TEXT",
+                    "value": "Error states"
+                  },
+                  "Type": {
+                    "value": "Storybook project",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "I208:20388;2:135;209:21361",
+                    "overriddenFields": [
+                      "fills"
+                    ]
+                  },
+                  {
+                    "id": "I208:20388;2:135;209:21361;1035:13181",
+                    "overriddenFields": [
+                      "fills"
+                    ]
+                  },
+                  {
+                    "id": "I208:20388;2:135;209:21362",
+                    "overriddenFields": [
+                      "fills"
+                    ]
+                  }
+                ],
+                "children": [],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.27843138575553894,
+                      "b": 0.5215686559677124,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:e8c4c30dbd720aa292e1b366176b5c081d18fd59/10588:695"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.27843138575553894,
+                      "b": 0.5215686559677124,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:e8c4c30dbd720aa292e1b366176b5c081d18fd59/10588:695"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 0.27843138575553894,
+                  "b": 0.5215686559677124,
+                  "a": 1
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingLeft": 40,
+                "paddingRight": 40,
+                "itemSpacing": 8,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 480,
+                  "height": 270
+                },
+                "absoluteRenderBounds": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 480,
+                  "height": 270
+                },
+                "targetAspectRatio": {
+                  "x": 1920,
+                  "y": 1080
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "itemSpacing": 10,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 480,
+              "height": 270
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 480,
+              "height": 270
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      }
+    ]
+  },
+  "components": {
+    "207:37095": {
+      "key": "ea1e2bc383de9f7252ca29b298754f5a5d423532",
+      "name": "Error modal",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "207:29822": {
+      "key": "1f5863cd3c59133dbeabe949661d37fa475494b8",
+      "name": "Button",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "207:29422": {
+      "key": "7f5fcca03633bd9e98bb6ad5ec635c2dfdda4dc1",
+      "name": "Type=Stock examples",
+      "description": "",
+      "remote": true,
+      "componentSetId": "207:29421",
+      "documentationLinks": []
+    },
+    "207:37089": {
+      "key": "78421c4f5f3e4c8ff2883dc32391c8a85cfb0b3a",
+      "name": "Default",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "202:29282": {
+      "key": "d470412ee8c39058025732e7143429079ae9b804",
+      "name": "Bright=false",
+      "description": "",
+      "remote": true,
+      "componentSetId": "202:29281",
+      "documentationLinks": []
+    },
+    "202:29292": {
+      "key": "2bc155b9942affbb606b3f9d1753373225280baa",
+      "name": "type=dot",
+      "description": "",
+      "remote": true,
+      "componentSetId": "202:29291",
+      "documentationLinks": []
+    },
+    "202:29791": {
+      "key": "25cd62563ca40679289633ba8e7da88d3525221b",
+      "name": "Source",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "202:29786": {
+      "key": "7d5bcd7ef163b4718828dbc84b083261b3127c31",
+      "name": "Inverted=true",
+      "description": "",
+      "remote": true,
+      "componentSetId": "202:29784",
+      "documentationLinks": []
+    },
+    "219:22043": {
+      "key": "413a0811db869d4e51b5dd394fd71468eb75f35e",
+      "name": "Preview",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "207:29654": {
+      "key": "49c10bc796c939138811899f969e3220f779f402",
+      "name": "Type=Preview",
+      "description": "",
+      "remote": true,
+      "componentSetId": "207:29651",
+      "documentationLinks": []
+    },
+    "202:29785": {
+      "key": "ac5f8b1f0d57bf212b61ffcfb1925bef46c268c1",
+      "name": "Inverted=false",
+      "description": "",
+      "remote": true,
+      "componentSetId": "202:29784",
+      "documentationLinks": []
+    },
+    "209:21366": {
+      "key": "3d2d575357442f9367954c9b91646d9dc04e95f0",
+      "name": "Render fail",
+      "description": "",
+      "remote": false,
+      "documentationLinks": []
+    },
+    "202:4563": {
+      "key": "0c4b65cb299be3d26bca006f466b47c96698403c",
+      "name": "Type=Critical, Compact=false",
+      "description": "",
+      "remote": true,
+      "componentSetId": "202:4562",
+      "documentationLinks": []
+    },
+    "208:20361": {
+      "key": "79fc7f9faae1d490624f73f752a497f884041865",
+      "name": "Type=Storybook project",
+      "description": "",
+      "remote": true,
+      "componentSetId": "208:20360",
+      "documentationLinks": []
+    }
+  },
+  "componentSets": {
+    "207:29421": {
+      "key": "11e9f02cc4146c5fd9424b9b88d834a101094fec",
+      "name": "Sidebar",
+      "description": "",
+      "remote": true
+    },
+    "202:29281": {
+      "key": "7870689ba49b152ede3a2f55230692254f1948b0",
+      "name": "Annotation",
+      "description": "",
+      "remote": true
+    },
+    "202:29291": {
+      "key": "e7c06e7594362078a8995f781827c8d2808dbf41",
+      "name": "Pointer",
+      "description": "",
+      "remote": true
+    },
+    "202:29784": {
+      "key": "90bdf505966846940b4f5fe2c89a68b9d7726b8d",
+      "name": "_Source",
+      "description": "",
+      "remote": true
+    },
+    "207:29651": {
+      "key": "cfdc75678801f60b1b1689ab04ec61a0ca140413",
+      "name": "Toolbar",
+      "description": "",
+      "remote": true
+    },
+    "202:4562": {
+      "key": "cf6c674f05ab7bb11e3bc5d0b8d422f09f574406",
+      "name": "Badge",
+      "description": "",
+      "remote": true
+    },
+    "208:20360": {
+      "key": "72e6f28dcebfbab0de50f249d43a830243d4bf6f",
+      "name": "Thumbnail",
+      "description": "",
+      "remote": true
+    }
+  },
+  "schemaVersion": 0,
+  "styles": {
+    "1:509": {
+      "key": "19b1d46526d56a4b81a16c80cbeef2889ed3a222",
+      "name": "Border/Gray-Tr10",
+      "styleType": "FILL",
+      "remote": true,
+      "description": "000000"
+    },
+    "1:508": {
+      "key": "17ac0c497a8066bb5a440119033f41e359c4ef93",
+      "name": "Monochrome/lightest",
+      "styleType": "FILL",
+      "remote": true,
+      "description": "FFFFFF"
+    },
+    "1:510": {
+      "key": "a561ee9f51c7cab3a0b74365c6d3e904075b992a",
+      "name": "Blue S50/2",
+      "styleType": "FILL",
+      "remote": true,
+      "description": ""
+    },
+    "202:29278": {
+      "key": "52a7dc4f4edfd58a6fdb82e4e681bce4ba7d7829",
+      "name": "typography/text/medium",
+      "styleType": "TEXT",
+      "remote": true,
+      "description": ""
+    },
+    "202:29280": {
+      "key": "2d8d9cfb4f8a04b49dad3d22174578d9e2c17dcf",
+      "name": "typography/code/small",
+      "styleType": "TEXT",
+      "remote": true,
+      "description": ""
+    },
+    "202:29781": {
+      "key": "863f7ec5ab5b2f347b06962f48a19a8d035a8b19",
+      "name": "Card",
+      "styleType": "EFFECT",
+      "remote": true,
+      "description": ""
+    },
+    "202:7873": {
+      "key": "36c55c5eb0f932e81ece649e51fbde493bc0ab8f",
+      "name": "typography/code/medium",
+      "styleType": "TEXT",
+      "remote": true,
+      "description": ""
+    },
+    "202:5191": {
+      "key": "053ad03a257f923cc636140f32f438734770e855",
+      "name": "typography/text/mediumBold",
+      "styleType": "TEXT",
+      "remote": true,
+      "description": ""
+    }
+  },
+  "name": "Error States",
+  "lastModified": "2026-04-09T16:26:21Z",
+  "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/6adb7997-dfda-41f0-927c-c710ce5696e6?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWCZHCZBGZX%2F20260705%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260705T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=aca5b573694a1673839d7b63851853649ff853739226b2a1a6c7bf76a812377a",
+  "version": "2340494070937107033",
+  "role": "editor",
+  "editorType": "figma",
+  "linkAccess": "inherit"
+}

--- a/packages/cuttings/src/__fixtures__/api/error-states/GetFileComponentSets.json
+++ b/packages/cuttings/src/__fixtures__/api/error-states/GetFileComponentSets.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "component_sets": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/error-states/GetFileComponents.json
+++ b/packages/cuttings/src/__fixtures__/api/error-states/GetFileComponents.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "components": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/error-states/GetFileStyles.json
+++ b/packages/cuttings/src/__fixtures__/api/error-states/GetFileStyles.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "styles": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFile.json
+++ b/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFile.json
@@ -1,0 +1,17678 @@
+{
+  "document": {
+    "id": "0:0",
+    "name": "Document",
+    "type": "DOCUMENT",
+    "scrollBehavior": "SCROLLS",
+    "children": [
+      {
+        "id": "2:29975",
+        "name": "proposal",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "2:32205",
+            "name": "proposal",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "2:29976",
+                "name": "resting",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "rectangleCornerRadii": {
+                    "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    },
+                    "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    },
+                    "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    },
+                    "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    }
+                  },
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "children": [
+                  {
+                    "id": "2:29977",
+                    "name": "Sidebar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "individualStrokeWeights": {
+                        "BORDER_RIGHT_WEIGHT": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15696",
+                    "componentProperties": {
+                      "Type": {
+                        "value": "Stock examples",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:29977",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9699999690055847,
+                          "g": 0.9793334603309631,
+                          "b": 0.9900000095367432,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9699999690055847,
+                          "g": 0.9793334603309631,
+                          "b": 0.9900000095367432,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 1,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "overflowDirection": "VERTICAL_SCROLLING",
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingLeft": 12,
+                    "paddingRight": 12,
+                    "paddingTop": 16,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 250,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 250,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:29978",
+                    "name": "Right",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 250,
+                      "y": 0,
+                      "width": 1010,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 250,
+                      "y": 0,
+                      "width": 1010,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "cornerRadius": 8,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -1,
+                  "y": -1,
+                  "width": 1262,
+                  "height": 972
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:29982",
+                "name": "open",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "rectangleCornerRadii": {
+                    "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    },
+                    "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    },
+                    "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    },
+                    "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                    }
+                  },
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "children": [
+                  {
+                    "id": "2:29983",
+                    "name": "Sidebar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "individualStrokeWeights": {
+                        "BORDER_RIGHT_WEIGHT": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15696",
+                    "componentProperties": {
+                      "Type": {
+                        "value": "Stock examples",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:29983",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9699999690055847,
+                          "g": 0.9793334603309631,
+                          "b": 0.9900000095367432,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9699999690055847,
+                          "g": 0.9793334603309631,
+                          "b": 0.9900000095367432,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 1,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "overflowDirection": "VERTICAL_SCROLLING",
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingLeft": 12,
+                    "paddingRight": 12,
+                    "paddingTop": 16,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1363,
+                      "y": 0,
+                      "width": 250,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1363,
+                      "y": 0,
+                      "width": 250,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:29984",
+                    "name": "Right",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1613,
+                      "y": 0,
+                      "width": 1010,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1613,
+                      "y": 0,
+                      "width": 1010,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:29988",
+                    "name": "Published - Share menu",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                        }
+                      ]
+                    },
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingTop": 4,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2373,
+                      "y": 42,
+                      "width": 240,
+                      "height": 88
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2368,
+                      "y": 39,
+                      "width": 250,
+                      "height": 101
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [
+                      {
+                        "type": "DROP_SHADOW",
+                        "visible": true,
+                        "color": {
+                          "r": 0,
+                          "g": 0,
+                          "b": 0,
+                          "a": 0.05000000074505806
+                        },
+                        "blendMode": "NORMAL",
+                        "offset": {
+                          "x": 0,
+                          "y": 5
+                        },
+                        "radius": 5,
+                        "showShadowBehindNode": false
+                      },
+                      {
+                        "type": "DROP_SHADOW",
+                        "visible": true,
+                        "color": {
+                          "r": 0,
+                          "g": 0,
+                          "b": 0,
+                          "a": 0.10000000149011612
+                        },
+                        "blendMode": "NORMAL",
+                        "offset": {
+                          "x": 0,
+                          "y": 0
+                        },
+                        "radius": 3,
+                        "showShadowBehindNode": false
+                      }
+                    ],
+                    "styles": {
+                      "effect": "2:22631"
+                    },
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [],
+                "fills": [],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "cornerRadius": 8,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "OUTSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 1363,
+                  "y": 0,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 1362,
+                  "y": -1,
+                  "width": 1262,
+                  "height": 972
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -100,
+              "y": -100,
+              "width": 2823,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": -100,
+              "y": -100,
+              "width": 2823,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "2:29974",
+        "name": "---",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "0:1",
+        "name": "sketches",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "2:3559",
+            "name": "Modal",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/2420:67"
+                }
+              ]
+            },
+            "children": [
+              {
+                "id": "2:3560",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "paddingLeft": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "paddingTop": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                  },
+                  "paddingRight": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "individualStrokeWeights": {
+                    "BORDER_RIGHT_WEIGHT": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                    }
+                  },
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "componentId": "2:15698",
+                "componentProperties": {
+                  "Type": {
+                    "value": "TimeFrame",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "2:3560",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [
+                  {
+                    "id": "I2:3560;1002:8434",
+                    "name": "SidebarMasthead",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      }
+                    },
+                    "componentId": "2:15317",
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "SPACE_BETWEEN",
+                    "paddingLeft": 8,
+                    "paddingTop": 2,
+                    "paddingBottom": 2,
+                    "itemSpacing": 88,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 16,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 16,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 42,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8435",
+                    "name": "Search",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      }
+                    },
+                    "componentId": "2:15321",
+                    "componentProperties": {
+                      "Show Keyboard shortcut#1001:6": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show clear button#1001:5": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingTop": 16,
+                    "paddingBottom": 16,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 58,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 58,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8436",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8436;987:6826",
+                      "I2:3560;1002:8436;987:7725",
+                      "I2:3560;1002:8436;988:7229",
+                      "I2:3560;1002:8436;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Introduction"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 122,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 122,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8438",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8438;987:6826",
+                      "I2:3560;1002:8438;987:7725",
+                      "I2:3560;1002:8438;988:7229",
+                      "I2:3560;1002:8438;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Changelog"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 150,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 150,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8439",
+                    "name": "SidebarHeading",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+                      }
+                    },
+                    "componentId": "2:15460",
+                    "exposedInstances": [
+                      "I2:3560;1002:8439;1001:7629",
+                      "I2:3560;1002:8439;1890:75801"
+                    ],
+                    "componentProperties": {
+                      "Expanded": {
+                        "value": "True",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingTop": 14,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 178,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 178,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8440",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8440;987:6826",
+                      "I2:3560;1002:8440;987:7725",
+                      "I2:3560;1002:8440;988:7229",
+                      "I2:3560;1002:8440;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Badges"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 224,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 224,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8441",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8441;987:6826",
+                      "I2:3560;1002:8441;987:7725",
+                      "I2:3560;1002:8441;988:7229",
+                      "I2:3560;1002:8441;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Buttons"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 252,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 252,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8442",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8442;987:6826",
+                      "I2:3560;1002:8442;987:7725",
+                      "I2:3560;1002:8442;988:7229",
+                      "I2:3560;1002:8442;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Charts"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 280,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 280,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8443",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:3560;1002:8443;988:9793",
+                      "I2:3560;1002:8443;988:9479",
+                      "I2:3560;1002:8443;988:9481",
+                      "I2:3560;1002:8443;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "DatePicker"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 308,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 308,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8444",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:3560;1002:8444;988:9793",
+                      "I2:3560;1002:8444;988:9479",
+                      "I2:3560;1002:8444;988:9481",
+                      "I2:3560;1002:8444;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "PieChart"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 336,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 336,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8445",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:3560;1002:8445;988:9793",
+                      "I2:3560;1002:8445;988:9479",
+                      "I2:3560;1002:8445;988:9481",
+                      "I2:3560;1002:8445;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "RangeSlider"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 364,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 364,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8446",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:3560;1002:8446;988:9793",
+                      "I2:3560;1002:8446;988:9479",
+                      "I2:3560;1002:8446;988:9481",
+                      "I2:3560;1002:8446;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "SparkLine"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 392,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 392,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8447",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:3560;1002:8447;988:9793",
+                      "I2:3560;1002:8447;988:9479",
+                      "I2:3560;1002:8447;988:9481",
+                      "I2:3560;1002:8447;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "TimeFrame"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 420,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 420,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8448",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:3a667684135a6c2e9bad9e297d41201b67f7e750/57:1982"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15383",
+                    "exposedInstances": [
+                      "I2:3560;1002:8448;988:9811",
+                      "I2:3560;1002:8448;988:9524",
+                      "I2:3560;1002:8448;988:9526",
+                      "I2:3560;1002:8448;988:9526;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Overview"
+                      },
+                      "Level": {
+                        "value": "3",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 44,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 448,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 448,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8449",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:3a667684135a6c2e9bad9e297d41201b67f7e750/57:1982"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15383",
+                    "exposedInstances": [
+                      "I2:3560;1002:8449;988:9811",
+                      "I2:3560;1002:8449;988:9524",
+                      "I2:3560;1002:8449;988:9526",
+                      "I2:3560;1002:8449;988:9526;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "No selection"
+                      },
+                      "Level": {
+                        "value": "3",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 44,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 476,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 476,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8450",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:3a667684135a6c2e9bad9e297d41201b67f7e750/57:1982"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15385",
+                    "exposedInstances": [
+                      "I2:3560;1002:8450;988:9823",
+                      "I2:3560;1002:8450;988:9538",
+                      "I2:3560;1002:8450;988:9540",
+                      "I2:3560;1002:8450;988:9540;993:8029"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Afternoon"
+                      },
+                      "Level": {
+                        "value": "3",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Selected",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0.41066646575927734,
+                      "b": 0.8799999952316284,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 44,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 504,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 504,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8451",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:3a667684135a6c2e9bad9e297d41201b67f7e750/57:1982"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15383",
+                    "exposedInstances": [
+                      "I2:3560;1002:8451;988:9811",
+                      "I2:3560;1002:8451;988:9524",
+                      "I2:3560;1002:8451;988:9526",
+                      "I2:3560;1002:8451;988:9526;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "All Day"
+                      },
+                      "Level": {
+                        "value": "3",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 44,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 532,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 532,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8452",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8452;987:6826",
+                      "I2:3560;1002:8452;987:7725",
+                      "I2:3560;1002:8452;988:7229",
+                      "I2:3560;1002:8452;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Images"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 560,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 560,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8453",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8453;987:6826",
+                      "I2:3560;1002:8453;987:7725",
+                      "I2:3560;1002:8453;988:7229",
+                      "I2:3560;1002:8453;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Interstitials"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 588,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 588,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8454",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8454;987:6826",
+                      "I2:3560;1002:8454;987:7725",
+                      "I2:3560;1002:8454;988:7229",
+                      "I2:3560;1002:8454;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Tooltips"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 616,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 616,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8455",
+                    "name": "SidebarHeading",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+                      }
+                    },
+                    "componentId": "2:15460",
+                    "exposedInstances": [
+                      "I2:3560;1002:8455;1001:7629",
+                      "I2:3560;1002:8455;1890:75801"
+                    ],
+                    "componentProperties": {
+                      "Expanded": {
+                        "value": "True",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingTop": 14,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 644,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 644,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8456",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8456;987:6826",
+                      "I2:3560;1002:8456;987:7725",
+                      "I2:3560;1002:8456;988:7229",
+                      "I2:3560;1002:8456;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "AccountMenu"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 690,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 690,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8457",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8457;987:6826",
+                      "I2:3560;1002:8457;987:7725",
+                      "I2:3560;1002:8457;988:7229",
+                      "I2:3560;1002:8457;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "ActivityItem"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 718,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 718,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8458",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8458;987:6826",
+                      "I2:3560;1002:8458;987:7725",
+                      "I2:3560;1002:8458;988:7229",
+                      "I2:3560;1002:8458;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "ActivityList"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 746,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 746,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8459",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8459;987:6826",
+                      "I2:3560;1002:8459;987:7725",
+                      "I2:3560;1002:8459;988:7229",
+                      "I2:3560;1002:8459;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "BuildItem"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 774,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 774,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8460",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8460;987:6826",
+                      "I2:3560;1002:8460;987:7725",
+                      "I2:3560;1002:8460;988:7229",
+                      "I2:3560;1002:8460;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Footer"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 802,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 802,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8461",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8461;987:6826",
+                      "I2:3560;1002:8461;987:7725",
+                      "I2:3560;1002:8461;988:7229",
+                      "I2:3560;1002:8461;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Header"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 830,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 830,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8462",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8462;987:6826",
+                      "I2:3560;1002:8462;987:7725",
+                      "I2:3560;1002:8462;988:7229",
+                      "I2:3560;1002:8462;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "NewAppForm"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 858,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 858,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8463",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8463;987:6826",
+                      "I2:3560;1002:8463;987:7725",
+                      "I2:3560;1002:8463;988:7229",
+                      "I2:3560;1002:8463;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Pagination"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 886,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 886,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1002:8464",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:3560;1002:8464;987:6826",
+                      "I2:3560;1002:8464;987:7725",
+                      "I2:3560;1002:8464;988:7229",
+                      "I2:3560;1002:8464;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Sidebar"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 914,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 914,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:3560;1248:28294",
+                    "name": "Test widget",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15612",
+                    "componentProperties": {
+                      "Show Visual tests#1460:0": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Status": {
+                        "value": "Not run",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "Collapsed": {
+                        "value": "true",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingTop": 4,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 12,
+                      "y": 890,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 12,
+                      "y": 890,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "BOTTOM",
+                      "horizontal": "LEFT_RIGHT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 250,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 250,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:3561",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [
+                  {
+                    "id": "2:3562",
+                    "name": "Toolbar",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                        }
+                      ]
+                    },
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "opacity": 0.15000000596046448,
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.14901961386203766,
+                          "g": 0.3333333432674408,
+                          "b": 0.45098039507865906,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:14a9bb79e1e6487da0424ba8484678fa28a5b8b4/986:69"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 0,
+                      "bottom": 1,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingRight": 10,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 250,
+                      "y": 0,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 250,
+                      "y": 0,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:3616",
+                    "name": "Preview",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                        }
+                      ]
+                    },
+                    "componentId": "2:8728",
+                    "componentProperties": {
+                      "Show Highlights#1456:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Content": {
+                        "value": "TimeFrame",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:3616",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "CENTER",
+                    "paddingLeft": 32,
+                    "paddingRight": 32,
+                    "paddingTop": 32,
+                    "paddingBottom": 32,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 250,
+                      "y": 40,
+                      "width": 1010,
+                      "height": 451
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 250,
+                      "y": 40,
+                      "width": 1010,
+                      "height": 451
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:3617",
+                    "name": "Frame 336",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "strokesIncludedInLayout": true,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 250,
+                      "y": 491,
+                      "width": 1010,
+                      "height": 451
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 250,
+                      "y": 491,
+                      "width": 1010,
+                      "height": 451
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 250,
+                  "y": 0,
+                  "width": 1010,
+                  "height": 942
+                },
+                "absoluteRenderBounds": {
+                  "x": 250,
+                  "y": 0,
+                  "width": 1010,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:3630",
+                "name": "Modal",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [
+                  {
+                    "id": "2:3631",
+                    "name": "Container",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "paddingTop": 6,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 406,
+                      "y": 241,
+                      "width": 448,
+                      "height": 488
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 339,
+                      "y": 178,
+                      "width": 582,
+                      "height": 622
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "HUG",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [
+                      {
+                        "type": "DROP_SHADOW",
+                        "visible": true,
+                        "color": {
+                          "r": 0,
+                          "g": 0,
+                          "b": 0,
+                          "a": 0.25
+                        },
+                        "blendMode": "NORMAL",
+                        "offset": {
+                          "x": 0,
+                          "y": 4
+                        },
+                        "radius": 67,
+                        "showShadowBehindNode": false
+                      }
+                    ],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "opacity": 0.800000011920929,
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 0.800000011920929
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "counterAxisAlignItems": "CENTER",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingLeft": 10,
+                "paddingRight": 10,
+                "paddingTop": 10,
+                "paddingBottom": 10,
+                "itemSpacing": 10,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 1260,
+                  "height": 942
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutPositioning": "ABSOLUTE",
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [
+                  {
+                    "type": "BACKGROUND_BLUR",
+                    "visible": true,
+                    "radius": 24
+                  }
+                ],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/2420:67"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/2420:67"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9647058844566345,
+              "g": 0.9764705896377563,
+              "b": 0.9882352948188782,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 1260,
+              "height": 942
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 1260,
+              "height": 942
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "2:14420",
+            "name": "Button",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "componentId": "2:16157",
+            "componentProperties": {
+              "Show Sidebar#1319:1": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Show Addon panel#1319:0": {
+                "type": "BOOLEAN",
+                "value": true
+              }
+            },
+            "overrides": [],
+            "children": [
+              {
+                "id": "I2:14420;1311:31726",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "componentPropertyReferences": {
+                  "visible": "Show Sidebar#1319:1"
+                },
+                "boundVariables": {
+                  "paddingLeft": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "paddingTop": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                  },
+                  "paddingRight": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "individualStrokeWeights": {
+                    "BORDER_RIGHT_WEIGHT": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                    }
+                  },
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "componentId": "2:15696",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [],
+                "children": [
+                  {
+                    "id": "I2:14420;1311:31726;1234:36386",
+                    "name": "SidebarMasthead",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      }
+                    },
+                    "componentId": "2:15317",
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "SPACE_BETWEEN",
+                    "paddingLeft": 8,
+                    "paddingTop": 2,
+                    "paddingBottom": 2,
+                    "itemSpacing": 88,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1068,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1068,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 42,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:36387",
+                    "name": "Search",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      }
+                    },
+                    "componentId": "2:15321",
+                    "componentProperties": {
+                      "Show Keyboard shortcut#1001:6": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show clear button#1001:5": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingTop": 16,
+                    "paddingBottom": 16,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1110,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1110,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:36388",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:36388;987:6826",
+                      "I2:14420;1311:31726;1234:36388;987:7725",
+                      "I2:14420;1311:31726;1234:36388;988:7229",
+                      "I2:14420;1311:31726;1234:36388;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Configure your project"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1174,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1174,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:36391",
+                    "name": "SidebarHeading",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+                      }
+                    },
+                    "componentId": "2:15460",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:36391;1001:7629",
+                      "I2:14420;1311:31726;1234:36391;1890:75801"
+                    ],
+                    "componentProperties": {
+                      "Expanded": {
+                        "value": "True",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingTop": 14,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1202,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1202,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:36393",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:36393;987:6826",
+                      "I2:14420;1311:31726;1234:36393;987:7725",
+                      "I2:14420;1311:31726;1234:36393;988:7229",
+                      "I2:14420;1311:31726;1234:36393;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Button"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1248,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1248,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37381",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37381;988:9793",
+                      "I2:14420;1311:31726;1234:37381;988:9479",
+                      "I2:14420;1311:31726;1234:37381;988:9481",
+                      "I2:14420;1311:31726;1234:37381;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1276,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1276,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37419",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15382",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37419;988:9805",
+                      "I2:14420;1311:31726;1234:37419;988:9493",
+                      "I2:14420;1311:31726;1234:37419;988:9495",
+                      "I2:14420;1311:31726;1234:37419;988:9495;993:8029"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Primary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Selected",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0.41066646575927734,
+                      "b": 0.8799999952316284,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1304,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1304,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37441",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37441;988:9793",
+                      "I2:14420;1311:31726;1234:37441;988:9479",
+                      "I2:14420;1311:31726;1234:37441;988:9481",
+                      "I2:14420;1311:31726;1234:37441;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Secondary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1332,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1332,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37461",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37461;988:9793",
+                      "I2:14420;1311:31726;1234:37461;988:9479",
+                      "I2:14420;1311:31726;1234:37461;988:9481",
+                      "I2:14420;1311:31726;1234:37461;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Large"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1360,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1360,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37462",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37462;988:9793",
+                      "I2:14420;1311:31726;1234:37462;988:9479",
+                      "I2:14420;1311:31726;1234:37462;988:9481",
+                      "I2:14420;1311:31726;1234:37462;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Small"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1388,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1388,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:36394",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:36394;987:6826",
+                      "I2:14420;1311:31726;1234:36394;987:7725",
+                      "I2:14420;1311:31726;1234:36394;988:7229",
+                      "I2:14420;1311:31726;1234:36394;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Header"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1416,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1416,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37500",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37500;988:9793",
+                      "I2:14420;1311:31726;1234:37500;988:9479",
+                      "I2:14420;1311:31726;1234:37500;988:9481",
+                      "I2:14420;1311:31726;1234:37500;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1444,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1444,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37501",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37501;988:9793",
+                      "I2:14420;1311:31726;1234:37501;988:9479",
+                      "I2:14420;1311:31726;1234:37501;988:9481",
+                      "I2:14420;1311:31726;1234:37501;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1472,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1472,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37502",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37502;988:9793",
+                      "I2:14420;1311:31726;1234:37502;988:9479",
+                      "I2:14420;1311:31726;1234:37502;988:9481",
+                      "I2:14420;1311:31726;1234:37502;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1500,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1500,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:36404",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:36404;987:6826",
+                      "I2:14420;1311:31726;1234:36404;987:7725",
+                      "I2:14420;1311:31726;1234:36404;988:7229",
+                      "I2:14420;1311:31726;1234:36404;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Page"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1528,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1528,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37559",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37559;988:9793",
+                      "I2:14420;1311:31726;1234:37559;988:9479",
+                      "I2:14420;1311:31726;1234:37559;988:9481",
+                      "I2:14420;1311:31726;1234:37559;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1556,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1556,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1234:37560",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:14420;1311:31726;1234:37560;988:9793",
+                      "I2:14420;1311:31726;1234:37560;988:9479",
+                      "I2:14420;1311:31726;1234:37560;988:9481",
+                      "I2:14420;1311:31726;1234:37560;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1584,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1584,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31726;1248:25012",
+                    "name": "Test widget",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15612",
+                    "componentProperties": {
+                      "Show Visual tests#1460:0": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Status": {
+                        "value": "Not run",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "Collapsed": {
+                        "value": "true",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingTop": 4,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -176,
+                      "y": 1970,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -176,
+                      "y": 1970,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "BOTTOM",
+                      "horizontal": "LEFT_RIGHT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -188,
+                  "y": 1052,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -188,
+                  "y": 1052,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "I2:14420;1311:31727",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [
+                  {
+                    "id": "I2:14420;1311:31728",
+                    "name": "Toolbar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:47baa634bfa618ba812aaaa6be970c56a017f790/57:1996"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:624145bd12b971eee92b8fdc957a1fd3b33620e5/57:1981"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15926",
+                    "exposedInstances": [
+                      "I2:14420;1311:31728;1003:10849"
+                    ],
+                    "componentProperties": {
+                      "Show View addon panel button #1334:2": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show Open in Editor Button#1834:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show sidebar button#1334:1": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show rerun button#1334:7": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show tabs#1334:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Type": {
+                        "value": "Story",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 0,
+                      "bottom": 1,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingRight": 10,
+                    "itemSpacing": 12,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 62,
+                      "y": 1052,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 62,
+                      "y": 1052,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 40,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1311:31729",
+                    "name": "Preview",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                        }
+                      ]
+                    },
+                    "componentId": "2:8742",
+                    "componentProperties": {
+                      "Show Highlights#1456:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Content": {
+                        "value": "Button",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "CENTER",
+                    "paddingLeft": 32,
+                    "paddingRight": 32,
+                    "paddingTop": 32,
+                    "paddingBottom": 32,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 62,
+                      "y": 1092,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 62,
+                      "y": 1092,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:14420;1314:29716",
+                    "name": "Addon panel",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "componentPropertyReferences": {
+                      "visible": "Show Addon panel#1319:0"
+                    },
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:16108",
+                    "exposedInstances": [
+                      "I2:14420;1314:29716;1367:44327",
+                      "I2:14420;1314:29716;1367:44327;1367:43027"
+                    ],
+                    "componentProperties": {
+                      "Show Save story tools#1350:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Panel": {
+                        "value": "Controls",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 1,
+                      "right": 0,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "OUTSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "strokesIncludedInLayout": true,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 62,
+                      "y": 1702,
+                      "width": 1010,
+                      "height": 320
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 62,
+                      "y": 1701,
+                      "width": 1010,
+                      "height": 321
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 62,
+                  "y": 1052,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 62,
+                  "y": 1052,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -188,
+              "y": 1052,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -188,
+              "y": 1052,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "2:22163",
+            "name": "Button",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "2:22164",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "paddingLeft": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "paddingTop": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                  },
+                  "paddingRight": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "individualStrokeWeights": {
+                    "BORDER_RIGHT_WEIGHT": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                    }
+                  },
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "componentId": "2:15696",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "2:22164",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [
+                  {
+                    "id": "I2:22164;1234:36386",
+                    "name": "SidebarMasthead",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      }
+                    },
+                    "componentId": "2:15317",
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "SPACE_BETWEEN",
+                    "paddingLeft": 8,
+                    "paddingTop": 2,
+                    "paddingBottom": 2,
+                    "itemSpacing": 88,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1068,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1068,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 42,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:36387",
+                    "name": "Search",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      }
+                    },
+                    "componentId": "2:15321",
+                    "componentProperties": {
+                      "Show Keyboard shortcut#1001:6": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show clear button#1001:5": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingTop": 16,
+                    "paddingBottom": 16,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1110,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1110,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:36388",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:22164;1234:36388;987:6826",
+                      "I2:22164;1234:36388;987:7725",
+                      "I2:22164;1234:36388;988:7229",
+                      "I2:22164;1234:36388;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Configure your project"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1174,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1174,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:36391",
+                    "name": "SidebarHeading",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+                      }
+                    },
+                    "componentId": "2:15460",
+                    "exposedInstances": [
+                      "I2:22164;1234:36391;1001:7629",
+                      "I2:22164;1234:36391;1890:75801"
+                    ],
+                    "componentProperties": {
+                      "Expanded": {
+                        "value": "True",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingTop": 14,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1202,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1202,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:36393",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:22164;1234:36393;987:6826",
+                      "I2:22164;1234:36393;987:7725",
+                      "I2:22164;1234:36393;988:7229",
+                      "I2:22164;1234:36393;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Button"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1248,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1248,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37381",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37381;988:9793",
+                      "I2:22164;1234:37381;988:9479",
+                      "I2:22164;1234:37381;988:9481",
+                      "I2:22164;1234:37381;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1276,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1276,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37419",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15382",
+                    "exposedInstances": [
+                      "I2:22164;1234:37419;988:9805",
+                      "I2:22164;1234:37419;988:9493",
+                      "I2:22164;1234:37419;988:9495",
+                      "I2:22164;1234:37419;988:9495;993:8029"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Primary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Selected",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0.41066646575927734,
+                      "b": 0.8799999952316284,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1304,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1304,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37441",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37441;988:9793",
+                      "I2:22164;1234:37441;988:9479",
+                      "I2:22164;1234:37441;988:9481",
+                      "I2:22164;1234:37441;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Secondary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1332,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1332,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37461",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37461;988:9793",
+                      "I2:22164;1234:37461;988:9479",
+                      "I2:22164;1234:37461;988:9481",
+                      "I2:22164;1234:37461;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Large"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1360,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1360,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37462",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37462;988:9793",
+                      "I2:22164;1234:37462;988:9479",
+                      "I2:22164;1234:37462;988:9481",
+                      "I2:22164;1234:37462;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Small"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1388,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1388,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:36394",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:22164;1234:36394;987:6826",
+                      "I2:22164;1234:36394;987:7725",
+                      "I2:22164;1234:36394;988:7229",
+                      "I2:22164;1234:36394;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Header"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1416,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1416,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37500",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37500;988:9793",
+                      "I2:22164;1234:37500;988:9479",
+                      "I2:22164;1234:37500;988:9481",
+                      "I2:22164;1234:37500;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1444,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1444,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37501",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37501;988:9793",
+                      "I2:22164;1234:37501;988:9479",
+                      "I2:22164;1234:37501;988:9481",
+                      "I2:22164;1234:37501;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1472,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1472,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37502",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37502;988:9793",
+                      "I2:22164;1234:37502;988:9479",
+                      "I2:22164;1234:37502;988:9481",
+                      "I2:22164;1234:37502;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1500,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1500,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:36404",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:22164;1234:36404;987:6826",
+                      "I2:22164;1234:36404;987:7725",
+                      "I2:22164;1234:36404;988:7229",
+                      "I2:22164;1234:36404;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Page"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1528,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1528,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37559",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37559;988:9793",
+                      "I2:22164;1234:37559;988:9479",
+                      "I2:22164;1234:37559;988:9481",
+                      "I2:22164;1234:37559;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1556,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1556,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1234:37560",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:22164;1234:37560;988:9793",
+                      "I2:22164;1234:37560;988:9479",
+                      "I2:22164;1234:37560;988:9481",
+                      "I2:22164;1234:37560;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1584,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1584,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:22164;1248:25012",
+                    "name": "Test widget",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15612",
+                    "componentProperties": {
+                      "Show Visual tests#1460:0": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Status": {
+                        "value": "Not run",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "Collapsed": {
+                        "value": "true",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingTop": 4,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1356,
+                      "y": 1970,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1356,
+                      "y": 1970,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "BOTTOM",
+                      "horizontal": "LEFT_RIGHT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 1344,
+                  "y": 1052,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 1344,
+                  "y": 1052,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:22165",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [
+                  {
+                    "id": "2:22166",
+                    "name": "Toolbar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:47baa634bfa618ba812aaaa6be970c56a017f790/57:1996"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:624145bd12b971eee92b8fdc957a1fd3b33620e5/57:1981"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15926",
+                    "exposedInstances": [
+                      "I2:22166;1003:10849"
+                    ],
+                    "componentProperties": {
+                      "Show View addon panel button #1334:2": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show Open in Editor Button#1834:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show sidebar button#1334:1": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show rerun button#1334:7": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show tabs#1334:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Type": {
+                        "value": "Story",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:22166",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      },
+                      {
+                        "id": "I2:22166;1003:10956",
+                        "overriddenFields": [
+                          "componentProperties"
+                        ]
+                      },
+                      {
+                        "id": "I2:22166;1003:10956;30:9751",
+                        "overriddenFields": [
+                          "boundVariables",
+                          "fills",
+                          "name"
+                        ]
+                      },
+                      {
+                        "id": "I2:22166;1003:10956;30:9751;3136:531",
+                        "overriddenFields": [
+                          "fills",
+                          "inheritFillStyleId"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 0,
+                      "bottom": 1,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingRight": 10,
+                    "itemSpacing": 12,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1594,
+                      "y": 1052,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1594,
+                      "y": 1052,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 40,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:22167",
+                    "name": "Preview",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                        }
+                      ]
+                    },
+                    "componentId": "2:8742",
+                    "componentProperties": {
+                      "Show Highlights#1456:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Content": {
+                        "value": "Button",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:22167",
+                        "overriddenFields": [
+                          "height",
+                          "primaryAxisSizingMode",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "CENTER",
+                    "paddingLeft": 32,
+                    "paddingRight": 32,
+                    "paddingTop": 32,
+                    "paddingBottom": 32,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1594,
+                      "y": 1092,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1594,
+                      "y": 1092,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:22168",
+                    "name": "Addon panel",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:16108",
+                    "exposedInstances": [
+                      "I2:22168;1367:44327",
+                      "I2:22168;1367:44327;1367:43027"
+                    ],
+                    "componentProperties": {
+                      "Show Save story tools#1350:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Panel": {
+                        "value": "Controls",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:22168",
+                        "overriddenFields": [
+                          "clipsContent",
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 1,
+                      "right": 0,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "OUTSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "strokesIncludedInLayout": true,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 1594,
+                      "y": 1702,
+                      "width": 1010,
+                      "height": 320
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 1594,
+                      "y": 1701,
+                      "width": 1010,
+                      "height": 321
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 1594,
+                  "y": 1052,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 1594,
+                  "y": 1052,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1344,
+              "y": 1052,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 1344,
+              "y": 1052,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "2:27325",
+            "name": "Button",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "2:27326",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "paddingLeft": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "paddingTop": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                  },
+                  "paddingRight": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "individualStrokeWeights": {
+                    "BORDER_RIGHT_WEIGHT": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                    }
+                  },
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "componentId": "2:15696",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "2:27326",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [
+                  {
+                    "id": "I2:27326;1234:36386",
+                    "name": "SidebarMasthead",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      }
+                    },
+                    "componentId": "2:15317",
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "SPACE_BETWEEN",
+                    "paddingLeft": 8,
+                    "paddingTop": 2,
+                    "paddingBottom": 2,
+                    "itemSpacing": 88,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2140,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2140,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 42,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:36387",
+                    "name": "Search",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      }
+                    },
+                    "componentId": "2:15321",
+                    "componentProperties": {
+                      "Show Keyboard shortcut#1001:6": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show clear button#1001:5": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingTop": 16,
+                    "paddingBottom": 16,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2182,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2182,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:36388",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:27326;1234:36388;987:6826",
+                      "I2:27326;1234:36388;987:7725",
+                      "I2:27326;1234:36388;988:7229",
+                      "I2:27326;1234:36388;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Configure your project"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2246,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2246,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:36391",
+                    "name": "SidebarHeading",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+                      }
+                    },
+                    "componentId": "2:15460",
+                    "exposedInstances": [
+                      "I2:27326;1234:36391;1001:7629",
+                      "I2:27326;1234:36391;1890:75801"
+                    ],
+                    "componentProperties": {
+                      "Expanded": {
+                        "value": "True",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingTop": 14,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2274,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2274,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:36393",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:27326;1234:36393;987:6826",
+                      "I2:27326;1234:36393;987:7725",
+                      "I2:27326;1234:36393;988:7229",
+                      "I2:27326;1234:36393;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Button"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2320,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2320,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37381",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37381;988:9793",
+                      "I2:27326;1234:37381;988:9479",
+                      "I2:27326;1234:37381;988:9481",
+                      "I2:27326;1234:37381;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2348,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2348,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37419",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15382",
+                    "exposedInstances": [
+                      "I2:27326;1234:37419;988:9805",
+                      "I2:27326;1234:37419;988:9493",
+                      "I2:27326;1234:37419;988:9495",
+                      "I2:27326;1234:37419;988:9495;993:8029"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Primary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Selected",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0.41066646575927734,
+                      "b": 0.8799999952316284,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2376,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2376,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37441",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37441;988:9793",
+                      "I2:27326;1234:37441;988:9479",
+                      "I2:27326;1234:37441;988:9481",
+                      "I2:27326;1234:37441;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Secondary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2404,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2404,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37461",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37461;988:9793",
+                      "I2:27326;1234:37461;988:9479",
+                      "I2:27326;1234:37461;988:9481",
+                      "I2:27326;1234:37461;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Large"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2432,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2432,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37462",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37462;988:9793",
+                      "I2:27326;1234:37462;988:9479",
+                      "I2:27326;1234:37462;988:9481",
+                      "I2:27326;1234:37462;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Small"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2460,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2460,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:36394",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:27326;1234:36394;987:6826",
+                      "I2:27326;1234:36394;987:7725",
+                      "I2:27326;1234:36394;988:7229",
+                      "I2:27326;1234:36394;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Header"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2488,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2488,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37500",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37500;988:9793",
+                      "I2:27326;1234:37500;988:9479",
+                      "I2:27326;1234:37500;988:9481",
+                      "I2:27326;1234:37500;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2516,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2516,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37501",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37501;988:9793",
+                      "I2:27326;1234:37501;988:9479",
+                      "I2:27326;1234:37501;988:9481",
+                      "I2:27326;1234:37501;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2544,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2544,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37502",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37502;988:9793",
+                      "I2:27326;1234:37502;988:9479",
+                      "I2:27326;1234:37502;988:9481",
+                      "I2:27326;1234:37502;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2572,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2572,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:36404",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:27326;1234:36404;987:6826",
+                      "I2:27326;1234:36404;987:7725",
+                      "I2:27326;1234:36404;988:7229",
+                      "I2:27326;1234:36404;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Page"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2600,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2600,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37559",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37559;988:9793",
+                      "I2:27326;1234:37559;988:9479",
+                      "I2:27326;1234:37559;988:9481",
+                      "I2:27326;1234:37559;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2628,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2628,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1234:37560",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:27326;1234:37560;988:9793",
+                      "I2:27326;1234:37560;988:9479",
+                      "I2:27326;1234:37560;988:9481",
+                      "I2:27326;1234:37560;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 2656,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 2656,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:27326;1248:25012",
+                    "name": "Test widget",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15612",
+                    "componentProperties": {
+                      "Show Visual tests#1460:0": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Status": {
+                        "value": "Not run",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "Collapsed": {
+                        "value": "true",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingTop": 4,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -236,
+                      "y": 3042,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -236,
+                      "y": 3042,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "BOTTOM",
+                      "horizontal": "LEFT_RIGHT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -248,
+                  "y": 2124,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -248,
+                  "y": 2124,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:27327",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [
+                  {
+                    "id": "2:27328",
+                    "name": "Toolbar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:47baa634bfa618ba812aaaa6be970c56a017f790/57:1996"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:624145bd12b971eee92b8fdc957a1fd3b33620e5/57:1981"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15926",
+                    "exposedInstances": [
+                      "I2:27328;1003:10849"
+                    ],
+                    "componentProperties": {
+                      "Show View addon panel button #1334:2": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show Open in Editor Button#1834:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show sidebar button#1334:1": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show rerun button#1334:7": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show tabs#1334:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Type": {
+                        "value": "Story",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:27328",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      },
+                      {
+                        "id": "I2:27328;1003:10956",
+                        "overriddenFields": [
+                          "componentProperties"
+                        ]
+                      },
+                      {
+                        "id": "I2:27328;1003:10956;30:9751",
+                        "overriddenFields": [
+                          "boundVariables",
+                          "fills",
+                          "name"
+                        ]
+                      },
+                      {
+                        "id": "I2:27328;1003:10956;30:9751;3136:531",
+                        "overriddenFields": [
+                          "fills",
+                          "inheritFillStyleId"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 0,
+                      "bottom": 1,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingRight": 10,
+                    "itemSpacing": 12,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2,
+                      "y": 2124,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2,
+                      "y": 2124,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 40,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:27329",
+                    "name": "Preview",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                        }
+                      ]
+                    },
+                    "componentId": "2:8742",
+                    "componentProperties": {
+                      "Show Highlights#1456:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Content": {
+                        "value": "Button",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:27329",
+                        "overriddenFields": [
+                          "height",
+                          "primaryAxisSizingMode",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "CENTER",
+                    "paddingLeft": 32,
+                    "paddingRight": 32,
+                    "paddingTop": 32,
+                    "paddingBottom": 32,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2,
+                      "y": 2164,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2,
+                      "y": 2164,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:27330",
+                    "name": "Addon panel",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:16108",
+                    "exposedInstances": [
+                      "I2:27330;1367:44327",
+                      "I2:27330;1367:44327;1367:43027"
+                    ],
+                    "componentProperties": {
+                      "Show Save story tools#1350:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Panel": {
+                        "value": "Controls",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:27330",
+                        "overriddenFields": [
+                          "clipsContent",
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 1,
+                      "right": 0,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "OUTSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "strokesIncludedInLayout": true,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2,
+                      "y": 2774,
+                      "width": 1010,
+                      "height": 320
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2,
+                      "y": 2773,
+                      "width": 1010,
+                      "height": 321
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 2,
+                  "y": 2124,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 2,
+                  "y": 2124,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:27789",
+                "name": "Modal",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/2420:67"
+                    }
+                  ]
+                },
+                "children": [
+                  {
+                    "id": "2:27790",
+                    "name": "Sidebar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "individualStrokeWeights": {
+                        "BORDER_RIGHT_WEIGHT": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15698",
+                    "componentProperties": {
+                      "Type": {
+                        "value": "TimeFrame",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:27790",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9699999690055847,
+                          "g": 0.9793334603309631,
+                          "b": 0.9900000095367432,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.9699999690055847,
+                          "g": 0.9793334603309631,
+                          "b": 0.9900000095367432,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 1,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "overflowDirection": "VERTICAL_SCROLLING",
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingLeft": 12,
+                    "paddingRight": 12,
+                    "paddingTop": 16,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -248,
+                      "y": 2124,
+                      "width": 250,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -248,
+                      "y": 2124,
+                      "width": 250,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:27791",
+                    "name": "Right",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2,
+                      "y": 2124,
+                      "width": 1010,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2,
+                      "y": 2124,
+                      "width": 1010,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:27860",
+                    "name": "Modal",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "opacity": 0.800000011920929,
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "opacity": 0.800000011920929,
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 0.800000011920929
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "CENTER",
+                    "paddingLeft": 10,
+                    "paddingRight": 10,
+                    "paddingTop": 10,
+                    "paddingBottom": 10,
+                    "itemSpacing": 10,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": -248,
+                      "y": 2124,
+                      "width": 1260,
+                      "height": 970
+                    },
+                    "absoluteRenderBounds": {
+                      "x": -248,
+                      "y": 2124,
+                      "width": 1260,
+                      "height": 970
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [
+                      {
+                        "type": "BACKGROUND_BLUR",
+                        "visible": true,
+                        "radius": 24
+                      }
+                    ],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/2420:67"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9647058844566345,
+                      "g": 0.9764705896377563,
+                      "b": 0.9882352948188782,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:edd62e030fa851a3b10286e98a4cda80a8608594/2420:67"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9647058844566345,
+                  "g": 0.9764705896377563,
+                  "b": 0.9882352948188782,
+                  "a": 1
+                },
+                "layoutMode": "HORIZONTAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": -248,
+                  "y": 2124,
+                  "width": 1260,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": -248,
+                  "y": 2124,
+                  "width": 1260,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP_BOTTOM",
+                  "horizontal": "LEFT_RIGHT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutPositioning": "ABSOLUTE",
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -248,
+              "y": 2124,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -248,
+              "y": 2124,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "2:24254",
+            "name": "Button",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "2:24255",
+                "name": "Sidebar",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "paddingLeft": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "paddingTop": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                  },
+                  "paddingRight": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                  },
+                  "individualStrokeWeights": {
+                    "BORDER_RIGHT_WEIGHT": {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                    }
+                  },
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                    }
+                  ],
+                  "strokes": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                    }
+                  ]
+                },
+                "componentId": "2:15696",
+                "componentProperties": {
+                  "Type": {
+                    "value": "Stock examples",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "2:24255",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [
+                  {
+                    "id": "I2:24255;1234:36386",
+                    "name": "SidebarMasthead",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+                      }
+                    },
+                    "componentId": "2:15317",
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "SPACE_BETWEEN",
+                    "paddingLeft": 8,
+                    "paddingTop": 2,
+                    "paddingBottom": 2,
+                    "itemSpacing": 88,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1068,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1068,
+                      "width": 226,
+                      "height": 42
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 42,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:36387",
+                    "name": "Search",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+                      }
+                    },
+                    "componentId": "2:15321",
+                    "componentProperties": {
+                      "Show Keyboard shortcut#1001:6": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show clear button#1001:5": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "paddingTop": 16,
+                    "paddingBottom": 16,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1110,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1110,
+                      "width": 226,
+                      "height": 64
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:36388",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:24255;1234:36388;987:6826",
+                      "I2:24255;1234:36388;987:7725",
+                      "I2:24255;1234:36388;988:7229",
+                      "I2:24255;1234:36388;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Configure your project"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1174,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1174,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:36391",
+                    "name": "SidebarHeading",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+                      }
+                    },
+                    "componentId": "2:15460",
+                    "exposedInstances": [
+                      "I2:24255;1234:36391;1001:7629",
+                      "I2:24255;1234:36391;1890:75801"
+                    ],
+                    "componentProperties": {
+                      "Expanded": {
+                        "value": "True",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "visible": false,
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingTop": 14,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1202,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1202,
+                      "width": 226,
+                      "height": 46
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:36393",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:24255;1234:36393;987:6826",
+                      "I2:24255;1234:36393;987:7725",
+                      "I2:24255;1234:36393;988:7229",
+                      "I2:24255;1234:36393;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Button"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1248,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1248,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37381",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37381;988:9793",
+                      "I2:24255;1234:37381;988:9479",
+                      "I2:24255;1234:37381;988:9481",
+                      "I2:24255;1234:37381;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1276,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1276,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37419",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15382",
+                    "exposedInstances": [
+                      "I2:24255;1234:37419;988:9805",
+                      "I2:24255;1234:37419;988:9493",
+                      "I2:24255;1234:37419;988:9495",
+                      "I2:24255;1234:37419;988:9495;993:8029"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Primary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Selected",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0,
+                          "g": 0.41066646575927734,
+                          "b": 0.8799999952316284,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:42763323ce0ab32628e7403964eb34e7c36b709f/2252:196"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0.41066646575927734,
+                      "b": 0.8799999952316284,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1304,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1304,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37441",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37441;988:9793",
+                      "I2:24255;1234:37441;988:9479",
+                      "I2:24255;1234:37441;988:9481",
+                      "I2:24255;1234:37441;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Secondary"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1332,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1332,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37461",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37461;988:9793",
+                      "I2:24255;1234:37461;988:9479",
+                      "I2:24255;1234:37461;988:9481",
+                      "I2:24255;1234:37461;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Large"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1360,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1360,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37462",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37462;988:9793",
+                      "I2:24255;1234:37462;988:9479",
+                      "I2:24255;1234:37462;988:9481",
+                      "I2:24255;1234:37462;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Small"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1388,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1388,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:36394",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:24255;1234:36394;987:6826",
+                      "I2:24255;1234:36394;987:7725",
+                      "I2:24255;1234:36394;988:7229",
+                      "I2:24255;1234:36394;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Header"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1416,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1416,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37500",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37500;988:9793",
+                      "I2:24255;1234:37500;988:9479",
+                      "I2:24255;1234:37500;988:9481",
+                      "I2:24255;1234:37500;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Docs"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1444,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1444,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37501",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37501;988:9793",
+                      "I2:24255;1234:37501;988:9479",
+                      "I2:24255;1234:37501;988:9481",
+                      "I2:24255;1234:37501;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1472,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1472,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37502",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37502;988:9793",
+                      "I2:24255;1234:37502;988:9479",
+                      "I2:24255;1234:37502;988:9481",
+                      "I2:24255;1234:37502;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1500,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1500,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:36404",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15377",
+                    "exposedInstances": [
+                      "I2:24255;1234:36404;987:6826",
+                      "I2:24255;1234:36404;987:7725",
+                      "I2:24255;1234:36404;988:7229",
+                      "I2:24255;1234:36404;988:7229;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Page"
+                      },
+                      "Level": {
+                        "value": "1",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 8,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1528,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1528,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37559",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37559;988:9793",
+                      "I2:24255;1234:37559;988:9479",
+                      "I2:24255;1234:37559;988:9481",
+                      "I2:24255;1234:37559;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged In"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1556,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1556,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1234:37560",
+                    "name": "SidebarItem",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+                      },
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:607ace1769a2bedddc62f02c2adf05fb7b51acec/62:2093"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+                      },
+                      "rectangleCornerRadii": {
+                        "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        },
+                        "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                        }
+                      }
+                    },
+                    "componentId": "2:15380",
+                    "exposedInstances": [
+                      "I2:24255;1234:37560;988:9793",
+                      "I2:24255;1234:37560;988:9479",
+                      "I2:24255;1234:37560;988:9481",
+                      "I2:24255;1234:37560;988:9481;988:7130"
+                    ],
+                    "componentProperties": {
+                      "Show arrow#988:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show context menu button#988:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Text#60:0": {
+                        "type": "TEXT",
+                        "value": "Logged Out"
+                      },
+                      "Level": {
+                        "value": "2",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "State": {
+                        "value": "Default",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "cornerRadius": 4,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 26,
+                    "itemSpacing": 6,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1584,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1584,
+                      "width": 226,
+                      "height": 28
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minWidth": 200,
+                    "minHeight": 28,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:24255;1248:25012",
+                    "name": "Test widget",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15612",
+                    "componentProperties": {
+                      "Show Visual tests#1460:0": {
+                        "type": "BOOLEAN",
+                        "value": true
+                      },
+                      "Status": {
+                        "value": "Not run",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      },
+                      "Collapsed": {
+                        "value": "true",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "cornerRadius": 6,
+                    "cornerSmoothing": 0,
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingTop": 4,
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2719,
+                      "y": 1970,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2719,
+                      "y": 1970,
+                      "width": 226,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "BOTTOM",
+                      "horizontal": "LEFT_RIGHT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutPositioning": "ABSOLUTE",
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.9699999690055847,
+                      "g": 0.9793334603309631,
+                      "b": 0.9900000095367432,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 0.8680000305175781,
+                      "g": 0.8791999816894531,
+                      "b": 0.8920000195503235,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                      }
+                    }
+                  }
+                ],
+                "strokeWeight": 1,
+                "individualStrokeWeights": {
+                  "top": 0,
+                  "right": 1,
+                  "bottom": 0,
+                  "left": 0
+                },
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "overflowDirection": "VERTICAL_SCROLLING",
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 16,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 2707,
+                  "y": 1052,
+                  "width": 250,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 2707,
+                  "y": 1052,
+                  "width": 250,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 0,
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:24256",
+                "name": "Right",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "children": [
+                  {
+                    "id": "2:24257",
+                    "name": "Toolbar",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "itemSpacing": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:47baa634bfa618ba812aaaa6be970c56a017f790/57:1996"
+                      },
+                      "minHeight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:624145bd12b971eee92b8fdc957a1fd3b33620e5/57:1981"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:15926",
+                    "exposedInstances": [
+                      "I2:24257;1003:10849"
+                    ],
+                    "componentProperties": {
+                      "Show View addon panel button #1334:2": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show Open in Editor Button#1834:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show sidebar button#1334:1": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show rerun button#1334:7": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Show tabs#1334:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Type": {
+                        "value": "Story",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:24257",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      },
+                      {
+                        "id": "I2:24257;1003:10956",
+                        "overriddenFields": [
+                          "componentProperties",
+                          "primaryAxisSizingMode"
+                        ]
+                      },
+                      {
+                        "id": "I2:24257;1003:10956;34:10196",
+                        "overriddenFields": [
+                          "boundVariables",
+                          "fills",
+                          "name"
+                        ]
+                      },
+                      {
+                        "id": "I2:24257;1003:10956;34:10196;3136:531",
+                        "overriddenFields": [
+                          "fills",
+                          "inheritFillStyleId"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 0,
+                      "right": 0,
+                      "bottom": 1,
+                      "left": 0
+                    },
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingRight": 10,
+                    "itemSpacing": 12,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2957,
+                      "y": 1052,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2957,
+                      "y": 1052,
+                      "width": 1010,
+                      "height": 40
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 40,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:24258",
+                    "name": "Preview",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "paddingLeft": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingTop": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingRight": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "paddingBottom": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:133cf864d3a14e6148bcd9618901dbdb3566a8ea/57:1979"
+                      },
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                        }
+                      ]
+                    },
+                    "componentId": "2:8742",
+                    "componentProperties": {
+                      "Show Highlights#1456:0": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Content": {
+                        "value": "Button",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:24258",
+                        "overriddenFields": [
+                          "height",
+                          "primaryAxisSizingMode",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:12c7f68b7dfaf7c0d04a388dd188a6123289f4e7/12:1352"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "primaryAxisAlignItems": "CENTER",
+                    "paddingLeft": 32,
+                    "paddingRight": 32,
+                    "paddingTop": 32,
+                    "paddingBottom": 32,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2957,
+                      "y": 1092,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2957,
+                      "y": 1092,
+                      "width": 1010,
+                      "height": 610
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 1,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FILL",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "2:24259",
+                    "name": "Addon panel",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "fills": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                        }
+                      ],
+                      "strokes": [
+                        {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                        }
+                      ]
+                    },
+                    "componentId": "2:16108",
+                    "exposedInstances": [
+                      "I2:24259;1367:44327",
+                      "I2:24259;1367:44327;1367:43027"
+                    ],
+                    "componentProperties": {
+                      "Show Save story tools#1350:4": {
+                        "type": "BOOLEAN",
+                        "value": false
+                      },
+                      "Panel": {
+                        "value": "Controls",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [
+                      {
+                        "id": "2:24259",
+                        "overriddenFields": [
+                          "clipsContent",
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "fills": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 1,
+                          "g": 1,
+                          "b": 1,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                          }
+                        }
+                      }
+                    ],
+                    "strokes": [
+                      {
+                        "blendMode": "NORMAL",
+                        "type": "SOLID",
+                        "color": {
+                          "r": 0.8680000305175781,
+                          "g": 0.8791999816894531,
+                          "b": 0.8920000195503235,
+                          "a": 1
+                        },
+                        "boundVariables": {
+                          "color": {
+                            "type": "VARIABLE_ALIAS",
+                            "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                          }
+                        }
+                      }
+                    ],
+                    "strokeWeight": 1,
+                    "individualStrokeWeights": {
+                      "top": 1,
+                      "right": 0,
+                      "bottom": 0,
+                      "left": 0
+                    },
+                    "strokeAlign": "OUTSIDE",
+                    "backgroundColor": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "primaryAxisSizingMode": "FIXED",
+                    "strokesIncludedInLayout": true,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 2957,
+                      "y": 1702,
+                      "width": 1010,
+                      "height": 320
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 2957,
+                      "y": 1701,
+                      "width": 1010,
+                      "height": 321
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [],
+                "fills": [],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 2957,
+                  "y": 1052,
+                  "width": 1010,
+                  "height": 970
+                },
+                "absoluteRenderBounds": {
+                  "x": 2957,
+                  "y": 1052,
+                  "width": 1010,
+                  "height": 970
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "STRETCH",
+                "layoutGrow": 1,
+                "layoutSizingHorizontal": "FILL",
+                "layoutSizingVertical": "FILL",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              },
+              {
+                "id": "2:26024",
+                "name": "Published - Share menu",
+                "type": "FRAME",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                    }
+                  ]
+                },
+                "children": [
+                  {
+                    "id": "2:26025",
+                    "name": "MenuItem2",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "HORIZONTAL",
+                    "primaryAxisSizingMode": "FIXED",
+                    "counterAxisAlignItems": "CENTER",
+                    "paddingLeft": 4,
+                    "paddingRight": 4,
+                    "itemSpacing": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 3717,
+                      "y": 1098,
+                      "width": 240,
+                      "height": 80
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 3717,
+                      "y": 1098,
+                      "width": 240,
+                      "height": 80
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "minHeight": 32,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": false,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 1,
+                      "b": 1,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "cornerRadius": 6,
+                "cornerSmoothing": 0,
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "paddingTop": 4,
+                "paddingBottom": 4,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 3717,
+                  "y": 1094,
+                  "width": 240,
+                  "height": 88
+                },
+                "absoluteRenderBounds": {
+                  "x": 3712,
+                  "y": 1091,
+                  "width": 250,
+                  "height": 101
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutAlign": "INHERIT",
+                "layoutGrow": 0,
+                "layoutPositioning": "ABSOLUTE",
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "HUG",
+                "effects": [
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.05000000074505806
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 5
+                    },
+                    "radius": 5,
+                    "showShadowBehindNode": false
+                  },
+                  {
+                    "type": "DROP_SHADOW",
+                    "visible": true,
+                    "color": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0.10000000149011612
+                    },
+                    "blendMode": "NORMAL",
+                    "offset": {
+                      "x": 0,
+                      "y": 0
+                    },
+                    "radius": 3,
+                    "showShadowBehindNode": false
+                  }
+                ],
+                "styles": {
+                  "effect": "2:22631"
+                },
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 2707,
+              "y": 1052,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 2707,
+              "y": 1052,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "2:29889",
+        "name": "thumbnail",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "2:29973",
+            "name": "thumbnail",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [
+              {
+                "id": "2:29945",
+                "name": "Thumbnail",
+                "type": "INSTANCE",
+                "scrollBehavior": "SCROLLS",
+                "boundVariables": {
+                  "fills": [
+                    {
+                      "type": "VARIABLE_ALIAS",
+                      "id": "VariableID:e8c4c30dbd720aa292e1b366176b5c081d18fd59/10588:695"
+                    }
+                  ]
+                },
+                "componentId": "2:29919",
+                "exposedInstances": [
+                  "I2:29945;2:261"
+                ],
+                "componentProperties": {
+                  "Icon#2:8": {
+                    "type": "INSTANCE_SWAP",
+                    "value": "2:29890",
+                    "preferredValues": []
+                  },
+                  "Description#2:4": {
+                    "type": "TEXT",
+                    "value": "View on another device!"
+                  },
+                  "Title#2:0": {
+                    "type": "TEXT",
+                    "value": "QR code"
+                  },
+                  "Type": {
+                    "value": "Storybook project",
+                    "type": "VARIANT",
+                    "boundVariables": {}
+                  }
+                },
+                "overrides": [
+                  {
+                    "id": "I2:29945;2:135",
+                    "overriddenFields": [
+                      "height",
+                      "width"
+                    ]
+                  }
+                ],
+                "children": [
+                  {
+                    "id": "I2:29945;2:135",
+                    "name": "QR",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "boundVariables": {
+                      "size": {
+                        "x": {
+                          "type": "VARIABLE_ALIAS",
+                          "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+                        }
+                      }
+                    },
+                    "componentId": "2:22627",
+                    "overrides": [
+                      {
+                        "id": "I2:29945;2:135",
+                        "overriddenFields": [
+                          "height",
+                          "width"
+                        ]
+                      }
+                    ],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": true,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "absoluteBoundingBox": {
+                      "x": 40,
+                      "y": 70,
+                      "width": 14,
+                      "height": 14
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 40,
+                      "y": 70,
+                      "width": 14,
+                      "height": 14
+                    },
+                    "targetAspectRatio": {
+                      "x": 14,
+                      "y": 14
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:29945;1:87",
+                    "name": "Details",
+                    "type": "FRAME",
+                    "scrollBehavior": "SCROLLS",
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "layoutMode": "VERTICAL",
+                    "counterAxisSizingMode": "FIXED",
+                    "paddingBottom": 4,
+                    "layoutWrap": "NO_WRAP",
+                    "absoluteBoundingBox": {
+                      "x": 40,
+                      "y": 92,
+                      "width": 400,
+                      "height": 68
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 40,
+                      "y": 92,
+                      "width": 400,
+                      "height": 68
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "STRETCH",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FILL",
+                    "layoutSizingVertical": "HUG",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  },
+                  {
+                    "id": "I2:29945;2:261",
+                    "name": "Project",
+                    "type": "INSTANCE",
+                    "scrollBehavior": "SCROLLS",
+                    "componentId": "2:29911",
+                    "isExposedInstance": true,
+                    "componentProperties": {
+                      "Project": {
+                        "value": "Storybook",
+                        "type": "VARIANT",
+                        "boundVariables": {}
+                      }
+                    },
+                    "overrides": [],
+                    "children": [],
+                    "blendMode": "PASS_THROUGH",
+                    "clipsContent": false,
+                    "background": [],
+                    "fills": [],
+                    "strokes": [],
+                    "strokeWeight": 1,
+                    "strokeAlign": "INSIDE",
+                    "backgroundColor": {
+                      "r": 0,
+                      "g": 0,
+                      "b": 0,
+                      "a": 0
+                    },
+                    "absoluteBoundingBox": {
+                      "x": 40,
+                      "y": 168,
+                      "width": 32,
+                      "height": 32
+                    },
+                    "absoluteRenderBounds": {
+                      "x": 40,
+                      "y": 167.9996337890625,
+                      "width": 32,
+                      "height": 32.0003662109375
+                    },
+                    "targetAspectRatio": {
+                      "x": 26,
+                      "y": 26
+                    },
+                    "constraints": {
+                      "vertical": "TOP",
+                      "horizontal": "LEFT"
+                    },
+                    "layoutAlign": "INHERIT",
+                    "layoutGrow": 0,
+                    "layoutSizingHorizontal": "FIXED",
+                    "layoutSizingVertical": "FIXED",
+                    "effects": [],
+                    "interactions": [],
+                    "complexStrokeProperties": {
+                      "strokeType": "BASIC"
+                    }
+                  }
+                ],
+                "blendMode": "PASS_THROUGH",
+                "clipsContent": true,
+                "background": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.27843138575553894,
+                      "b": 0.5215686559677124,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:e8c4c30dbd720aa292e1b366176b5c081d18fd59/10588:695"
+                      }
+                    }
+                  }
+                ],
+                "fills": [
+                  {
+                    "blendMode": "NORMAL",
+                    "type": "SOLID",
+                    "color": {
+                      "r": 1,
+                      "g": 0.27843138575553894,
+                      "b": 0.5215686559677124,
+                      "a": 1
+                    },
+                    "boundVariables": {
+                      "color": {
+                        "type": "VARIABLE_ALIAS",
+                        "id": "VariableID:e8c4c30dbd720aa292e1b366176b5c081d18fd59/10588:695"
+                      }
+                    }
+                  }
+                ],
+                "strokes": [],
+                "strokeWeight": 1,
+                "strokeAlign": "INSIDE",
+                "backgroundColor": {
+                  "r": 1,
+                  "g": 0.27843138575553894,
+                  "b": 0.5215686559677124,
+                  "a": 1
+                },
+                "layoutMode": "VERTICAL",
+                "counterAxisSizingMode": "FIXED",
+                "primaryAxisSizingMode": "FIXED",
+                "primaryAxisAlignItems": "CENTER",
+                "paddingLeft": 40,
+                "paddingRight": 40,
+                "itemSpacing": 8,
+                "layoutWrap": "NO_WRAP",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 2.842170943040401e-14,
+                  "width": 480,
+                  "height": 270
+                },
+                "absoluteRenderBounds": {
+                  "x": 0,
+                  "y": 2.842170943040401e-14,
+                  "width": 480,
+                  "height": 270
+                },
+                "preserveRatio": true,
+                "targetAspectRatio": {
+                  "x": 1920,
+                  "y": 1080
+                },
+                "constraints": {
+                  "vertical": "TOP",
+                  "horizontal": "LEFT"
+                },
+                "layoutSizingHorizontal": "FIXED",
+                "layoutSizingVertical": "FIXED",
+                "effects": [],
+                "interactions": [],
+                "complexStrokeProperties": {
+                  "strokeType": "BASIC"
+                }
+              }
+            ],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 2.842170943040401e-14,
+              "width": 480,
+              "height": 270
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 2.842170943040401e-14,
+              "width": 480,
+              "height": 270
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      }
+    ]
+  },
+  "components": {
+    "2:15696": {
+      "key": "7f5fcca03633bd9e98bb6ad5ec635c2dfdda4dc1",
+      "name": "Type=Stock examples",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15695",
+      "documentationLinks": []
+    },
+    "2:15698": {
+      "key": "dc8099f72db98dbcff0df3ff21b0c970d0f90083",
+      "name": "Type=TimeFrame",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15695",
+      "documentationLinks": []
+    },
+    "2:15317": {
+      "key": "6c734e27d6b8860dabaca5eb89cd1807f1963dca",
+      "name": "SidebarMasthead",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "2:15321": {
+      "key": "41f942fbcba723018f34892c5f2aded35bf8266f",
+      "name": "Search",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "2:15377": {
+      "key": "0ee2feab0ba7622fb73d1fb781d64b13b7cbed28",
+      "name": "Level=1, State=Default",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15376",
+      "documentationLinks": []
+    },
+    "2:15460": {
+      "key": "818388883a4dea55d3b1b559f705efb565db350b",
+      "name": "Expanded=True",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15458",
+      "documentationLinks": []
+    },
+    "2:15380": {
+      "key": "f982c4cc2dd8d237f8d09e1c306bc1bae0cac226",
+      "name": "Level=2, State=Default",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15376",
+      "documentationLinks": []
+    },
+    "2:15383": {
+      "key": "7841843bae7324ed52a2494ef23606251108fd7b",
+      "name": "Level=3, State=Default",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15376",
+      "documentationLinks": []
+    },
+    "2:15385": {
+      "key": "eb3211391c99384272e4072ee30c15dacfba22af",
+      "name": "Level=3, State=Selected",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15376",
+      "documentationLinks": []
+    },
+    "2:15612": {
+      "key": "2d88246cc2353fa3ed6542214873807963af4a62",
+      "name": "Status=Not run, Collapsed=true",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15604",
+      "documentationLinks": []
+    },
+    "2:8728": {
+      "key": "666439b4270b07cfca6ad34b03a8b5c168a63db9",
+      "name": "Content=TimeFrame",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:8726",
+      "documentationLinks": []
+    },
+    "2:16157": {
+      "key": "1f5863cd3c59133dbeabe949661d37fa475494b8",
+      "name": "Button",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "2:15382": {
+      "key": "cada67c179f5c8f8af507c3bcbd46fab32449838",
+      "name": "Level=2, State=Selected",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15376",
+      "documentationLinks": []
+    },
+    "2:15926": {
+      "key": "3e16a8a02e3f3958e97875ddf6844eb479e71ac8",
+      "name": "Type=Story",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:15925",
+      "documentationLinks": []
+    },
+    "2:8742": {
+      "key": "640c3eb0ade0914dfa8829dfecadf490f416404b",
+      "name": "Content=Button",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:8726",
+      "documentationLinks": []
+    },
+    "2:16108": {
+      "key": "a1c62576d0fe060e560e97031d79b3f926996ef3",
+      "name": "Panel=Controls",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:16107",
+      "documentationLinks": []
+    },
+    "2:29919": {
+      "key": "79fc7f9faae1d490624f73f752a497f884041865",
+      "name": "Type=Storybook project",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:29918",
+      "documentationLinks": []
+    },
+    "2:22627": {
+      "key": "d22e47f3a2028d55638bb8b038545626ecd96bf3",
+      "name": "QR",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "2:29911": {
+      "key": "11286cc2a45a6479f86f04d591c699e2230927c9",
+      "name": "Project=Storybook",
+      "description": "",
+      "remote": true,
+      "componentSetId": "2:29910",
+      "documentationLinks": []
+    }
+  },
+  "componentSets": {
+    "2:15695": {
+      "key": "11e9f02cc4146c5fd9424b9b88d834a101094fec",
+      "name": "Sidebar",
+      "description": "",
+      "remote": true
+    },
+    "2:15376": {
+      "key": "98ac83715b152398497b5ec48bff583aff4abd48",
+      "name": "SidebarItem",
+      "description": "",
+      "remote": true
+    },
+    "2:15458": {
+      "key": "36f96be81f23e316eb89bd8e5be646c595eb7acf",
+      "name": "SidebarHeading",
+      "description": "",
+      "remote": true
+    },
+    "2:15604": {
+      "key": "4560d06f29f7dca01d23b93949ba3a513bf60904",
+      "name": "Test widget",
+      "description": "",
+      "remote": true
+    },
+    "2:8726": {
+      "key": "414689cd81f205985aece575adf6c6d4c348e968",
+      "name": "Preview",
+      "description": "",
+      "remote": true
+    },
+    "2:15925": {
+      "key": "cfdc75678801f60b1b1689ab04ec61a0ca140413",
+      "name": "Toolbar",
+      "description": "",
+      "remote": true
+    },
+    "2:16107": {
+      "key": "250f8fc98ff5ffd299b8fca4088061093add0b30",
+      "name": "Addon panel",
+      "description": "",
+      "remote": true
+    },
+    "2:29918": {
+      "key": "72e6f28dcebfbab0de50f249d43a830243d4bf6f",
+      "name": "Thumbnail",
+      "description": "",
+      "remote": true
+    },
+    "2:29910": {
+      "key": "db042e6bf72f2f3d168a5bb4bf02250031335c01",
+      "name": "Project",
+      "description": "",
+      "remote": true
+    }
+  },
+  "schemaVersion": 0,
+  "styles": {
+    "2:22631": {
+      "key": "e63db614830d17229fc655efb6b0c9fb66c08eb3",
+      "name": "Popover",
+      "styleType": "EFFECT",
+      "remote": true,
+      "description": ""
+    }
+  },
+  "name": "Steve's Figma API debug file",
+  "lastModified": "2026-07-06T07:05:48Z",
+  "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/718816b6-616d-4fb3-9433-3a58109dbd35?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWCZHCZBGZX%2F20260705%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260705T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=d0ce884e19844011c8ae397c44ef335c9250f5e7505ecebf931aa6a0a010db01",
+  "version": "2372999792189229679",
+  "role": "owner",
+  "editorType": "figma",
+  "linkAccess": "inherit"
+}

--- a/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFile.json
+++ b/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFile.json
@@ -17670,9 +17670,9 @@
   },
   "name": "Steve's Figma API debug file",
   "lastModified": "2026-07-06T07:05:48Z",
-  "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/718816b6-616d-4fb3-9433-3a58109dbd35?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWCZHCZBGZX%2F20260705%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260705T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=d0ce884e19844011c8ae397c44ef335c9250f5e7505ecebf931aa6a0a010db01",
+  "thumbnailUrl": "https://figma-thumbnails.example/redacted",
   "version": "2372999792189229679",
-  "role": "owner",
+  "role": "viewer",
   "editorType": "figma",
   "linkAccess": "inherit"
 }

--- a/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFileComponentSets.json
+++ b/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFileComponentSets.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "component_sets": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFileComponents.json
+++ b/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFileComponents.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "components": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFileStyles.json
+++ b/packages/cuttings/src/__fixtures__/api/figma-api-debug-file/GetFileStyles.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "styles": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFile.json
+++ b/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFile.json
@@ -1,0 +1,13022 @@
+{
+  "document": {
+    "id": "0:0",
+    "name": "Document",
+    "type": "DOCUMENT",
+    "scrollBehavior": "SCROLLS",
+    "children": [
+      {
+        "id": "3:2192",
+        "name": "proposal",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "4:2746",
+            "name": "WIP proposal",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a987b6636a74179018f34998b7dd6f35f9df732a/12:1348"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8240000009536743,
+                  "g": 0.8389333486557007,
+                  "b": 0.8560000061988831,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a987b6636a74179018f34998b7dd6f35f9df732a/12:1348"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 4,
+              "y": -32,
+              "width": 2820,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": 4,
+              "y": -32,
+              "width": 2820,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "62:34293",
+            "name": "WIP: Sidebar states",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 4,
+              "y": 1338,
+              "width": 3628,
+              "height": 1099
+            },
+            "absoluteRenderBounds": {
+              "x": 4,
+              "y": 1338,
+              "width": 3628,
+              "height": 1099
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "70:38474",
+            "name": "WIP: Filter popover",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 5,
+              "y": 2637,
+              "width": 780,
+              "height": 730
+            },
+            "absoluteRenderBounds": {
+              "x": 5,
+              "y": 2637,
+              "width": 780,
+              "height": 730
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "93:45862",
+            "name": "Interesting ideas - likely no-gos",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 5,
+              "y": 3567,
+              "width": 600,
+              "height": 448
+            },
+            "absoluteRenderBounds": {
+              "x": 5,
+              "y": 3567,
+              "width": 600,
+              "height": 448
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "173:6211",
+        "name": "concept: commenting",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "173:6212",
+            "name": "Commenting",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.36000001430511475,
+                  "g": 0.3973333239555359,
+                  "b": 0.4399999976158142,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 10600,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 10600,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "174:35072",
+        "name": "concept: review mode",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "174:35073",
+            "name": "Concept: Split view comparison",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:8de217a9476f3d1634201f91d9379e8542ae94a9/12:1347"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.7800000309944153,
+                  "g": 0.7986666560173035,
+                  "b": 0.8199999928474426,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:8de217a9476f3d1634201f91d9379e8542ae94a9/12:1347"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -2300,
+              "y": -585,
+              "width": 4600,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": -2300,
+              "y": -585,
+              "width": 4600,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "3:2190",
+        "name": "---",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "0:1",
+        "name": "sketches",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "1:4427",
+            "name": "Button",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "componentId": "359:29728",
+            "componentProperties": {
+              "Show Sidebar#1319:1": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Show Addon panel#1319:0": {
+                "type": "BOOLEAN",
+                "value": true
+              }
+            },
+            "overrides": [],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -630,
+              "y": -485,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -630,
+              "y": -485,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "1:6532",
+            "name": "Button",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1052,
+              "y": -485,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 1052,
+              "y": -485,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "41:2559",
+            "name": "WIP proposal",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a987b6636a74179018f34998b7dd6f35f9df732a/12:1348"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8240000009536743,
+                  "g": 0.8389333486557007,
+                  "b": 0.8560000061988831,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a987b6636a74179018f34998b7dd6f35f9df732a/12:1348"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -630,
+              "y": 750,
+              "width": 1460,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": -630,
+              "y": 750,
+              "width": 1460,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "48:9589",
+            "name": "State with updated stories and filter active",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -530,
+              "y": 2299,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -530,
+              "y": 2299,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10147",
+            "name": "Resting",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 968,
+              "y": 2199,
+              "width": 240,
+              "height": 282
+            },
+            "absoluteRenderBounds": {
+              "x": 963,
+              "y": 2196,
+              "width": 250,
+              "height": 295
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10266",
+            "name": "Resting",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1262,
+              "y": 2199,
+              "width": 240,
+              "height": 355
+            },
+            "absoluteRenderBounds": {
+              "x": 1257,
+              "y": 2196,
+              "width": 250,
+              "height": 368
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10507",
+            "name": "Tags",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1556,
+              "y": 2199,
+              "width": 240,
+              "height": 236
+            },
+            "absoluteRenderBounds": {
+              "x": 1551,
+              "y": 2196,
+              "width": 250,
+              "height": 249
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10710",
+            "name": "Tests",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1850,
+              "y": 2439,
+              "width": 240,
+              "height": 241
+            },
+            "absoluteRenderBounds": {
+              "x": 1845,
+              "y": 2436,
+              "width": 250,
+              "height": 254
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10729",
+            "name": "Accessibility",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1850,
+              "y": 2712,
+              "width": 240,
+              "height": 136
+            },
+            "absoluteRenderBounds": {
+              "x": 1845,
+              "y": 2709,
+              "width": 250,
+              "height": 149
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10748",
+            "name": "Visual",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1850,
+              "y": 2880,
+              "width": 240,
+              "height": 72
+            },
+            "absoluteRenderBounds": {
+              "x": 1845,
+              "y": 2877,
+              "width": 250,
+              "height": 85
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10765",
+            "name": "Stability (custom tags)",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1850,
+              "y": 2984,
+              "width": 240,
+              "height": 136
+            },
+            "absoluteRenderBounds": {
+              "x": 1845,
+              "y": 2981,
+              "width": 250,
+              "height": 149
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10784",
+            "name": "Docs",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1850,
+              "y": 2303,
+              "width": 240,
+              "height": 104
+            },
+            "absoluteRenderBounds": {
+              "x": 1845,
+              "y": 2300,
+              "width": 250,
+              "height": 117
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:10943",
+            "name": "New and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1850,
+              "y": 2199,
+              "width": 240,
+              "height": 72
+            },
+            "absoluteRenderBounds": {
+              "x": 1845,
+              "y": 2196,
+              "width": 250,
+              "height": 85
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:11171",
+            "name": "Annotation",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ad64b9b2b9dc03c2bc436501456549a8c21a449a/1919:347"
+                }
+              ]
+            },
+            "componentId": "48:11165",
+            "componentProperties": {
+              "Show Author#10651:1": {
+                "type": "BOOLEAN",
+                "value": false
+              },
+              "Author#1489:3": {
+                "type": "TEXT",
+                "value": "Author"
+              },
+              "Description#1489:0": {
+                "type": "TEXT",
+                "value": "All statuses need to change to unique icons.\nCircle is reserved to indicate “changed”"
+              },
+              "Bright": {
+                "value": "false",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "48:11171",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18000000715255737,
+                  "g": 0.19866666197776794,
+                  "b": 0.2199999988079071,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:ad64b9b2b9dc03c2bc436501456549a8c21a449a/1919:347"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.18000000715255737,
+                  "g": 0.19866666197776794,
+                  "b": 0.2199999988079071,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:ad64b9b2b9dc03c2bc436501456549a8c21a449a/1919:347"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.18000000715255737,
+              "g": 0.19866666197776794,
+              "b": 0.2199999988079071,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "paddingTop": 16,
+            "paddingBottom": 16,
+            "itemSpacing": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 968,
+              "y": 2569,
+              "width": 240,
+              "height": 112
+            },
+            "absoluteRenderBounds": {
+              "x": 952,
+              "y": 2561,
+              "width": 272,
+              "height": 144
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.30000001192092896
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 8
+                },
+                "radius": 16,
+                "showShadowBehindNode": true
+              }
+            ],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:12497",
+            "name": "with warnings - initial load",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -4017,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -4017,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:22221",
+            "name": "with warnings - initial load",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -3700,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -3700,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:11719",
+            "name": "Selected",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2149,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2149,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13015",
+            "name": "Selected",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1799,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -1799,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "48:11175",
+            "name": "with warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2499,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2499,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "52:7729",
+            "name": "with warnings - initial load",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2849,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2849,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "52:8266",
+            "name": "no warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2849,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2849,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "52:9725",
+            "name": "no warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2499,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2499,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "52:8034",
+            "name": "Sidebar",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "componentId": "359:29499",
+            "componentProperties": {
+              "Type": {
+                "value": "Stock examples",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "52:8034",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              },
+              {
+                "id": "I52:8034;1234:37441",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I52:8034;1234:37461",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I52:8034;1234:37462",
+                "overriddenFields": [
+                  "visible"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -3199,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -3199,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "52:9197",
+            "name": "Sidebar",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "componentId": "359:29500",
+            "componentProperties": {
+              "Type": {
+                "value": "Stock examples with warnings",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "52:9197",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              },
+              {
+                "id": "I52:9197;1333:24460",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I52:9197;1333:24461",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I52:9197;1333:24462",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I52:9197;1333:24470;1233:16349;1233:12190",
+                "overriddenFields": [
+                  "componentProperties",
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -3199,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -3199,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13354",
+            "name": "Selected",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -116,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -116,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13425",
+            "name": "Selected",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 234,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 234,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13496",
+            "name": "with warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -466,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -466,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13569",
+            "name": "with warnings - initial load",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -816,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -816,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13683",
+            "name": "no warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -816,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -816,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:18458",
+            "name": "no warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 158,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 158,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:15807",
+            "name": "no warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -466,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -466,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:17274",
+            "name": "Tooltip",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:247de00c30a7f215f2f15ca596de247d302797aa/61:2087"
+              }
+            },
+            "componentId": "53:10297",
+            "componentProperties": {
+              "Label#1040:0": {
+                "type": "TEXT",
+                "value": "Logged out: Has changes"
+              }
+            },
+            "overrides": [
+              {
+                "id": "54:17274",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "opacity": 0.6000000238418579,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "opacity": 0.6000000238418579,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "visible": false,
+                "type": "SOLID",
+                "color": {
+                  "r": 0.5920000076293945,
+                  "g": 0.5920000076293945,
+                  "b": 0.5920000076293945,
+                  "a": 1
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 0,
+            "strokeAlign": "CENTER",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0.6000000238418579
+            },
+            "layoutMode": "HORIZONTAL",
+            "paddingLeft": 6,
+            "paddingRight": 6,
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "itemSpacing": 10,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -187,
+              "y": 4596,
+              "width": 153,
+              "height": 24
+            },
+            "absoluteRenderBounds": {
+              "x": -187,
+              "y": 4596,
+              "width": 153,
+              "height": 24
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13940",
+            "name": "Sidebar",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "componentId": "359:29499",
+            "componentProperties": {
+              "Type": {
+                "value": "Stock examples",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "54:13940",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              },
+              {
+                "id": "I54:13940;1234:37441",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I54:13940;1234:37461",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I54:13940;1234:37462",
+                "overriddenFields": [
+                  "visible"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1166,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -1166,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:19962",
+            "name": "Sidebar",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "componentId": "359:29499",
+            "componentProperties": {
+              "Type": {
+                "value": "Stock examples",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1704,
+              "y": 4171,
+              "width": 250,
+              "height": 1080
+            },
+            "absoluteRenderBounds": {
+              "x": 1704,
+              "y": 4171,
+              "width": 250,
+              "height": 1080
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:19353",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 508,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 508,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:19638",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 848,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 848,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:20676",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1168,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 1168,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:21152",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 2024,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 2024,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:21840",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 2314,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 2314,
+              "y": 4171,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:23486",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1713,
+              "y": 7447,
+              "width": 250,
+              "height": 788
+            },
+            "absoluteRenderBounds": {
+              "x": -1713,
+              "y": 7447,
+              "width": 250,
+              "height": 788
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:27137",
+            "name": "Sidebar",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1423,
+              "y": 7447,
+              "width": 250,
+              "height": 788
+            },
+            "absoluteRenderBounds": {
+              "x": -1423,
+              "y": 7447,
+              "width": 250,
+              "height": 788
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:27693",
+            "name": "Tests run",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -625,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -625,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:31486",
+            "name": "Tests run – pass states hidden",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -275,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -275,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:29348",
+            "name": "Tests run",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -625,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -625,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:31715",
+            "name": "Tests run – pass states hidden",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -275,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -275,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:27920",
+            "name": "New and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -975,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -975,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:29577",
+            "name": "New and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -975,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -975,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:26189",
+            "name": "Search",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+              }
+            },
+            "componentId": "359:29489",
+            "componentProperties": {
+              "Show Keyboard shortcut#1001:6": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Show clear button#1001:5": {
+                "type": "BOOLEAN",
+                "value": false
+              }
+            },
+            "overrides": [
+              {
+                "id": "54:26189",
+                "overriddenFields": [
+                  "boundVariables",
+                  "height",
+                  "primaryAxisSizingMode",
+                  "width"
+                ]
+              },
+              {
+                "id": "I54:26189;1001:9467",
+                "overriddenFields": [
+                  "componentProperties",
+                  "primaryAxisSizingMode"
+                ]
+              },
+              {
+                "id": "I54:26189;1001:9467;34:10196",
+                "overriddenFields": [
+                  "boundVariables",
+                  "fills",
+                  "name"
+                ]
+              },
+              {
+                "id": "I54:26189;1001:9467;34:10196;1107:3134",
+                "overriddenFields": [
+                  "fills",
+                  "inheritFillStyleId"
+                ]
+              },
+              {
+                "id": "I54:26189;1001:9486;8:9585",
+                "overriddenFields": [
+                  "layoutGrow",
+                  "maxLines",
+                  "textAutoResize"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingTop": 16,
+            "paddingBottom": 8,
+            "itemSpacing": 6,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1705,
+              "y": 6557,
+              "width": 226,
+              "height": 56
+            },
+            "absoluteRenderBounds": {
+              "x": -1705,
+              "y": 6557,
+              "width": 226,
+              "height": 56
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:13941",
+            "name": "Sidebar",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "individualStrokeWeights": {
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "componentId": "359:29500",
+            "componentProperties": {
+              "Type": {
+                "value": "Stock examples with warnings",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "54:13941",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              },
+              {
+                "id": "I54:13941;1333:24460",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I54:13941;1333:24461",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I54:13941;1333:24462",
+                "overriddenFields": [
+                  "visible"
+                ]
+              },
+              {
+                "id": "I54:13941;1333:24470;1233:16349;1233:12190",
+                "overriddenFields": [
+                  "componentProperties",
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 1,
+              "bottom": 0,
+              "left": 0
+            },
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingTop": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1166,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -1166,
+              "y": 5213,
+              "width": 250,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:12469",
+            "name": "Icons",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              }
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "VERTICAL",
+            "itemSpacing": 12,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -3299,
+              "y": 3836,
+              "width": 77,
+              "height": 52
+            },
+            "absoluteRenderBounds": {
+              "x": -3299,
+              "y": 3836,
+              "width": 77,
+              "height": 52
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:16323",
+            "name": "Context menu",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                }
+              ]
+            },
+            "componentId": "54:16144",
+            "componentProperties": {
+              "Is story#1958:1": {
+                "type": "BOOLEAN",
+                "value": true
+              }
+            },
+            "overrides": [
+              {
+                "id": "54:16323",
+                "overriddenFields": [
+                  "height",
+                  "width"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -186,
+              "y": 4352,
+              "width": 260,
+              "height": 234
+            },
+            "absoluteRenderBounds": {
+              "x": -191,
+              "y": 4349,
+              "width": 270,
+              "height": 247
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:17023",
+            "name": "Context menu",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:efee958b9431f6c80d9a515e0d5d4aa2b57cefcb/1920:124"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -186,
+              "y": 4639,
+              "width": 260,
+              "height": 275
+            },
+            "absoluteRenderBounds": {
+              "x": -191,
+              "y": 4636,
+              "width": 270,
+              "height": 288
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:17270",
+            "name": "dimension",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              }
+            },
+            "componentId": "54:12460",
+            "componentProperties": {
+              "Show line#1885:62": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Label#1885:59": {
+                "type": "TEXT",
+                "value": "label"
+              },
+              "Horizontal": {
+                "value": "False",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "counterAxisAlignItems": "CENTER",
+            "itemSpacing": 12,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -193,
+              "y": 4941,
+              "width": 94,
+              "height": 64
+            },
+            "absoluteRenderBounds": {
+              "x": -193,
+              "y": 4940.5,
+              "width": 94,
+              "height": 65
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:23025",
+            "name": "Tree 2.0",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2583,
+              "y": 6693,
+              "width": 250,
+              "height": 738
+            },
+            "absoluteRenderBounds": {
+              "x": -2584,
+              "y": 6692,
+              "width": 252,
+              "height": 740
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:25741",
+            "name": "Tree 2.0",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1713,
+              "y": 6693,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -1714,
+              "y": 6692,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:26680",
+            "name": "Tree 2.0",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1423,
+              "y": 6693,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -1424,
+              "y": 6692,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:24381",
+            "name": "Tree 2.0",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2293,
+              "y": 6693,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -2294,
+              "y": 6692,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:25227",
+            "name": "Tree 2.0",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2003,
+              "y": 6693,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -2004,
+              "y": 6692,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:28147",
+            "name": "Tests run",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1675,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -1676,
+              "y": 9108,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:32251",
+            "name": "Tests run – pass states hidden",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1325,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -1326,
+              "y": 9108,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:30100",
+            "name": "Tests run",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1675,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -1676,
+              "y": 10018,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:32377",
+            "name": "Tests run – pass states hidden",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1325,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -1326,
+              "y": 10018,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "54:28273",
+            "name": "No warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2025,
+              "y": 9109,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -2026,
+              "y": 9108,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "60:30226",
+            "name": "No warnings",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:ceb24512bbcf6812c9185333d1c86ec1066a9a22/57:1999"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:422342c8bccb8c8a89b5b21adb8e77bf734895ad/1893:10"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2025,
+              "y": 10019,
+              "width": 250,
+              "height": 710
+            },
+            "absoluteRenderBounds": {
+              "x": -2026,
+              "y": 10018,
+              "width": 252,
+              "height": 712
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "90:43894",
+            "name": "WIP: Filter popover",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -377,
+              "y": 11313,
+              "width": 3601,
+              "height": 1265
+            },
+            "absoluteRenderBounds": {
+              "x": -377,
+              "y": 11313,
+              "width": 3601,
+              "height": 1265
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "99:46189",
+        "name": "sketches - ai panel",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "99:46191",
+            "name": "With new and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1311,
+              "y": -485,
+              "width": 1260,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -1311,
+              "y": -485,
+              "width": 1260,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "137:1363",
+            "name": "With new and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1517,
+              "y": 723,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -1517,
+              "y": 723,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "141:2135",
+            "name": "With new and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1517,
+              "y": 1823,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -1517,
+              "y": 1823,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "162:4487",
+            "name": "Commenting",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.36000001430511475,
+                  "g": 0.3973333239555359,
+                  "b": 0.4399999976158142,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": -6117,
+              "y": 4429,
+              "width": 10600,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": -6117,
+              "y": 4429,
+              "width": 10600,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "154:17593",
+            "name": "Toolbar overflow menu",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:4c542b0f7da12bd8a8d3823d6c455d2917ef70bb/987:15"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 6,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingTop": 4,
+            "paddingBottom": 4,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1079,
+              "y": 3116,
+              "width": 400,
+              "height": 128
+            },
+            "absoluteRenderBounds": {
+              "x": -1084,
+              "y": 3113,
+              "width": 410,
+              "height": 141
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "141:2870",
+            "name": "Button",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:0b5f37a172e8cea8213663e481962821572284d6/57:2030"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:0b5f37a172e8cea8213663e481962821572284d6/57:2030"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "minWidth": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+              },
+              "minHeight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+              },
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:2d0ae16fc2e9d40b2ab126ada1411090381f45bb/2252:191"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:49da653bb07b7fbb5fa75b76176f5df8bf4bdde1/2252:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:2d0ae16fc2e9d40b2ab126ada1411090381f45bb/2252:191"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:2d0ae16fc2e9d40b2ab126ada1411090381f45bb/2252:191"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:49da653bb07b7fbb5fa75b76176f5df8bf4bdde1/2252:108"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisAlignItems": "CENTER",
+            "primaryAxisAlignItems": "CENTER",
+            "paddingLeft": 7,
+            "paddingRight": 7,
+            "paddingTop": 6,
+            "paddingBottom": 6,
+            "itemSpacing": 6,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -486,
+              "y": 2921,
+              "width": 28,
+              "height": 28
+            },
+            "absoluteRenderBounds": {
+              "x": -486,
+              "y": 2921,
+              "width": 28,
+              "height": 28
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "minWidth": 28,
+            "minHeight": 28,
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "141:2851",
+            "name": "Button",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:0b5f37a172e8cea8213663e481962821572284d6/57:2030"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:0b5f37a172e8cea8213663e481962821572284d6/57:2030"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "minWidth": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+              },
+              "minHeight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+              },
+              "individualStrokeWeights": {
+                "BORDER_TOP_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_BOTTOM_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                },
+                "BORDER_RIGHT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:2d0ae16fc2e9d40b2ab126ada1411090381f45bb/2252:191"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:49da653bb07b7fbb5fa75b76176f5df8bf4bdde1/2252:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:2d0ae16fc2e9d40b2ab126ada1411090381f45bb/2252:191"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:2d0ae16fc2e9d40b2ab126ada1411090381f45bb/2252:191"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:49da653bb07b7fbb5fa75b76176f5df8bf4bdde1/2252:108"
+                  }
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisAlignItems": "CENTER",
+            "primaryAxisAlignItems": "CENTER",
+            "paddingLeft": 7,
+            "paddingRight": 7,
+            "paddingTop": 6,
+            "paddingBottom": 6,
+            "itemSpacing": 6,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -452,
+              "y": 2921,
+              "width": 28,
+              "height": 28
+            },
+            "absoluteRenderBounds": {
+              "x": -452,
+              "y": 2921,
+              "width": 28,
+              "height": 28
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "minWidth": 28,
+            "minHeight": 28,
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "141:2036",
+            "name": "New and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 1
+            },
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 126,
+              "y": 764,
+              "width": 400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 125,
+              "y": 764,
+              "width": 401,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "140:2024",
+            "name": "Button",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:0b5f37a172e8cea8213663e481962821572284d6/57:2030"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:0b5f37a172e8cea8213663e481962821572284d6/57:2030"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "minWidth": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+              },
+              "minHeight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:d34fcdeba97dd54a8e4407d09932dbb6d8a027f8/57:1978"
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                }
+              }
+            },
+            "componentId": "53:10455",
+            "componentProperties": {
+              "Right icon#1885:38": {
+                "type": "INSTANCE_SWAP",
+                "value": "1:71",
+                "preferredValues": []
+              },
+              "Show label#1888:65": {
+                "type": "BOOLEAN",
+                "value": false
+              },
+              "Show left icon#8:4": {
+                "type": "BOOLEAN",
+                "value": true
+              },
+              "Show right icon#1885:19": {
+                "type": "BOOLEAN",
+                "value": false
+              },
+              "Needs attention#2252:0": {
+                "type": "BOOLEAN",
+                "value": false
+              },
+              "Label#8:12": {
+                "type": "TEXT",
+                "value": "Label"
+              },
+              "Left icon#8:5": {
+                "type": "INSTANCE_SWAP",
+                "value": "53:10373",
+                "preferredValues": [
+                  {
+                    "type": "COMPONENT",
+                    "key": "9be362307dd105105ff4648be78f2a5ce3990e9c"
+                  }
+                ]
+              },
+              "Variant": {
+                "value": "Ghost",
+                "type": "VARIANT",
+                "boundVariables": {}
+              },
+              "Size": {
+                "value": "Small",
+                "type": "VARIANT",
+                "boundVariables": {}
+              },
+              "State": {
+                "value": "Default",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "140:2024",
+                "overriddenFields": [
+                  "height",
+                  "primaryAxisSizingMode",
+                  "width"
+                ]
+              },
+              {
+                "id": "I140:2024;30:9751",
+                "overriddenFields": [
+                  "boundVariables",
+                  "fills",
+                  "height",
+                  "name",
+                  "targetAspectRatio",
+                  "width"
+                ]
+              },
+              {
+                "id": "I140:2024;30:9751;2940:3403",
+                "overriddenFields": [
+                  "fills",
+                  "inheritFillStyleId"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "primaryAxisSizingMode": "FIXED",
+            "counterAxisAlignItems": "CENTER",
+            "primaryAxisAlignItems": "CENTER",
+            "paddingLeft": 7,
+            "paddingRight": 7,
+            "paddingTop": 6,
+            "paddingBottom": 6,
+            "itemSpacing": 6,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -17,
+              "y": 1624,
+              "width": 28,
+              "height": 28
+            },
+            "absoluteRenderBounds": {
+              "x": -17,
+              "y": 1624,
+              "width": 28,
+              "height": 28
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "minWidth": 28,
+            "minHeight": 28,
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "136:1127",
+            "name": "Frame 1268",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:9ce5140194adb99efb8575640d67cc3282b77b29/57:1995"
+              },
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:cc4dae8b83aa7dd20b9c538948817dd61d28a4a8/57:1974"
+              }
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "primaryAxisAlignItems": "MAX",
+            "paddingLeft": 12,
+            "paddingRight": 12,
+            "paddingBottom": 12,
+            "itemSpacing": 14,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 171,
+              "y": -485,
+              "width": 400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 171,
+              "y": -485,
+              "width": 400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "116:49993",
+            "name": "New and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "individualStrokeWeights": {
+                "BORDER_LEFT_WEIGHT": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:540d722622e4de4582a68e36e361982b63fb6455/59:2057"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 1
+            },
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "overflowDirection": "VERTICAL_SCROLLING",
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 627,
+              "y": -485,
+              "width": 400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 626,
+              "y": -485,
+              "width": 401,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "100:48659",
+            "name": "• TestScreen / TestCommentTooltip / Discussion open DEPRECATED",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:c4f10cae90f0cdfebc618d875f9d8616e95a8314/57:2000"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 8,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1925,
+              "y": 485,
+              "width": 400,
+              "height": 193
+            },
+            "absoluteRenderBounds": {
+              "x": -1930,
+              "y": 482,
+              "width": 410,
+              "height": 206
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.05000000074505806
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 5
+                },
+                "radius": 5,
+                "showShadowBehindNode": false
+              },
+              {
+                "type": "DROP_SHADOW",
+                "visible": true,
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 0.10000000149011612
+                },
+                "blendMode": "NORMAL",
+                "offset": {
+                  "x": 0,
+                  "y": 0
+                },
+                "radius": 3,
+                "showShadowBehindNode": false
+              }
+            ],
+            "styles": {
+              "effect": "41:3845"
+            },
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "100:48684",
+            "name": "Pinpoint / Regular DEPRECATED",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": -1964,
+              "y": 513,
+              "width": 20,
+              "height": 24
+            },
+            "absoluteRenderBounds": {
+              "x": -1964,
+              "y": 513,
+              "width": 20,
+              "height": 24
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "152:17303",
+            "name": "Group 368",
+            "type": "GROUP",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "rectangleCornerRadii": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": -556,
+              "y": 3041,
+              "width": 439,
+              "height": 221
+            },
+            "absoluteRenderBounds": {
+              "x": -556,
+              "y": 3041,
+              "width": 439,
+              "height": 221
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "154:18394",
+            "name": "Group 371",
+            "type": "GROUP",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "rectangleCornerRadii": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": 807,
+              "y": 3041,
+              "width": 439,
+              "height": 221
+            },
+            "absoluteRenderBounds": {
+              "x": 807,
+              "y": 3041,
+              "width": 439,
+              "height": 221
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "154:17696",
+            "name": "Group 370",
+            "type": "GROUP",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "rectangleCornerRadii": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": -311,
+              "y": 2854,
+              "width": 364,
+              "height": 44
+            },
+            "absoluteRenderBounds": {
+              "x": -311,
+              "y": 2854,
+              "width": 364,
+              "height": 44
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "154:17620",
+            "name": "Group 369",
+            "type": "GROUP",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "rectangleCornerRadii": [
+              0,
+              0,
+              0,
+              0
+            ],
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": -19,
+              "y": 3041,
+              "width": 439,
+              "height": 193
+            },
+            "absoluteRenderBounds": {
+              "x": -19,
+              "y": 3041,
+              "width": 439,
+              "height": 193
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "99:46423",
+            "name": "Addon panel",
+            "type": "INSTANCE",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                }
+              ],
+              "strokes": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                }
+              ]
+            },
+            "componentId": "53:12780",
+            "exposedInstances": [
+              "I99:46423;1367:44327",
+              "I99:46423;1367:44327;1367:43027"
+            ],
+            "componentProperties": {
+              "Show Save story tools#1350:4": {
+                "type": "BOOLEAN",
+                "value": false
+              },
+              "Panel": {
+                "value": "Controls",
+                "type": "VARIANT",
+                "boundVariables": {}
+              }
+            },
+            "overrides": [
+              {
+                "id": "99:46423",
+                "overriddenFields": [
+                  "clipsContent",
+                  "fills",
+                  "height",
+                  "individualStrokeWeights",
+                  "strokeWeight",
+                  "width"
+                ]
+              },
+              {
+                "id": "I99:46423;1318:45952;1003:11198;1003:10424",
+                "overriddenFields": [
+                  "componentProperties"
+                ]
+              }
+            ],
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.9699999690055847,
+                  "g": 0.9793334603309631,
+                  "b": 0.9900000095367432,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:155c3a9b3e28d77fdaf4bf0ce3ba813554856572/1920:107"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.8680000305175781,
+                  "g": 0.8791999816894531,
+                  "b": 0.8920000195503235,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:a07ed8f2ef489906ba683a711421304fb51cdadc/1945:154"
+                  }
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "individualStrokeWeights": {
+              "top": 0,
+              "right": 0,
+              "bottom": 0,
+              "left": 1
+            },
+            "strokeAlign": "OUTSIDE",
+            "backgroundColor": {
+              "r": 0.9699999690055847,
+              "g": 0.9793334603309631,
+              "b": 0.9900000095367432,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2438,
+              "y": 446,
+              "width": 366,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": -2439,
+              "y": 446,
+              "width": 367,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "100:48649",
+            "name": "Frame 854",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:565ae094ecb76fde28933765f1b562dca1668268/57:1975"
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                }
+              }
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.15000000596046448,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.15000000596046448,
+                  "g": 0.3343049883842468,
+                  "b": 0.45000001788139343,
+                  "a": 1
+                }
+              }
+            ],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "styles": {
+              "fills": "1:3792",
+              "strokes": "1:4172",
+              "fill": "1:3792",
+              "stroke": "1:4172"
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingLeft": 16,
+            "paddingRight": 16,
+            "paddingTop": 16,
+            "paddingBottom": 16,
+            "itemSpacing": 16,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -2317,
+              "y": 176,
+              "width": 860,
+              "height": 162
+            },
+            "absoluteRenderBounds": {
+              "x": -2317,
+              "y": 176,
+              "width": 860,
+              "height": 162
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "136:1126",
+            "name": "Frame 1270",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:706b07be0c8bd7fbdd623fad98346cf95a31eb53/1919:345"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0.41066646575927734,
+                  "b": 0.8799999952316284,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:706b07be0c8bd7fbdd623fad98346cf95a31eb53/1919:345"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0.41066646575927734,
+                  "b": 0.8799999952316284,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:706b07be0c8bd7fbdd623fad98346cf95a31eb53/1919:345"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0.41066646575927734,
+              "b": 0.8799999952316284,
+              "a": 1
+            },
+            "layoutMode": "VERTICAL",
+            "counterAxisSizingMode": "FIXED",
+            "paddingLeft": 10,
+            "paddingRight": 10,
+            "paddingTop": 10,
+            "paddingBottom": 10,
+            "itemSpacing": 10,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": -1046,
+              "y": -747,
+              "width": 1080,
+              "height": 132
+            },
+            "absoluteRenderBounds": {
+              "x": -1046,
+              "y": -747,
+              "width": 1080,
+              "height": 132
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "173:10411",
+        "name": "sketches - review mode",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "173:10412",
+            "name": "Cursor change",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "174:28185",
+            "name": "Cursor change",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 1500,
+              "y": 0,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 1500,
+              "y": 0,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "174:29537",
+            "name": "Cursor change",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 3000,
+              "y": 0,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 3000,
+              "y": 0,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "174:32270",
+            "name": "Cursor change",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 2875,
+              "y": 1513,
+              "width": 2441,
+              "height": 1290
+            },
+            "absoluteRenderBounds": {
+              "x": 2875,
+              "y": 1513,
+              "width": 2441,
+              "height": 1290
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "174:33691",
+            "name": "Concept: Split view comparison",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:8de217a9476f3d1634201f91d9379e8542ae94a9/12:1347"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.7800000309944153,
+                  "g": 0.7986666560173035,
+                  "b": 0.8199999928474426,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:8de217a9476f3d1634201f91d9379e8542ae94a9/12:1347"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 5401,
+              "y": -100,
+              "width": 4600,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": 5401,
+              "y": -100,
+              "width": 4600,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "284:4456",
+            "name": "removing extra Chrome",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:8de217a9476f3d1634201f91d9379e8542ae94a9/12:1347"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.7800000309944153,
+                  "g": 0.7986666560173035,
+                  "b": 0.8199999928474426,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:8de217a9476f3d1634201f91d9379e8542ae94a9/12:1347"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 5401,
+              "y": 1935,
+              "width": 4600,
+              "height": 1170
+            },
+            "absoluteRenderBounds": {
+              "x": 5401,
+              "y": 1935,
+              "width": 4600,
+              "height": 1170
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "284:5813",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 7001,
+              "y": 3679,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 7001,
+              "y": 3679,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "289:6127",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 8500,
+              "y": 3679,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 8500,
+              "y": 3679,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "326:6435",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 7001,
+              "y": 4861,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 7001,
+              "y": 4861,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "340:6961",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 8093,
+              "y": 4861,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 8093,
+              "y": 4861,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:25256",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 8093,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 8093,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:25621",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 9177,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 9177,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:26085",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 10279,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 10279,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:26429",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 11311,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 11311,
+              "y": 5998,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:27143",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:96edfc407b15e0efff4baf8804dc7a4cde61e6d8/1920:108"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 11311,
+              "y": 8442,
+              "width": 894,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 11311,
+              "y": 8442,
+              "width": 894,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "326:6790",
+            "name": "Frame 1276",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "itemSpacing": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:a0909f5382c4a50a644ef799a046288e6bb7c24d/57:1973"
+              }
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "primaryAxisSizingMode": "FIXED",
+            "paddingTop": 8,
+            "itemSpacing": 6,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 6654,
+              "y": 4881,
+              "width": 229,
+              "height": 36
+            },
+            "absoluteRenderBounds": {
+              "x": 6654,
+              "y": 4881,
+              "width": 229,
+              "height": 36
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "340:8189",
+            "name": "Content",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [],
+            "rectangleCornerRadii": [
+              0,
+              0,
+              7,
+              7
+            ],
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 1,
+              "g": 1,
+              "b": 1,
+              "a": 1
+            },
+            "absoluteBoundingBox": {
+              "x": 8952,
+              "y": 7081,
+              "width": 1438,
+              "height": 880
+            },
+            "absoluteRenderBounds": {
+              "x": 8952,
+              "y": 7081,
+              "width": 1438,
+              "height": 880
+            },
+            "constraints": {
+              "vertical": "TOP_BOTTOM",
+              "horizontal": "LEFT_RIGHT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:25478",
+            "name": "Label",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "paddingLeft": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingTop": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+              },
+              "paddingRight": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:071f6b4a6672e636f1536580816364342334853a/57:1972"
+              },
+              "paddingBottom": {
+                "type": "VARIABLE_ALIAS",
+                "id": "VariableID:a2a2942bd3f9cedbf7ededeb447a6225a81af30e/59:2055"
+              },
+              "rectangleCornerRadii": {
+                "RECTANGLE_TOP_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_TOP_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_LEFT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                },
+                "RECTANGLE_BOTTOM_RIGHT_CORNER_RADIUS": {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:66e1712fe1e1e7ba7886d92e9552cba78ea2bbbd/61:2088"
+                }
+              },
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                }
+              ]
+            },
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.36000001430511475,
+                  "g": 0.3973333239555359,
+                  "b": 0.4399999976158142,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                  }
+                }
+              }
+            ],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.36000001430511475,
+                  "g": 0.3973333239555359,
+                  "b": 0.4399999976158142,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:48199971d421cd0387a69e249019abbd2622fc09/1919:344"
+                  }
+                }
+              }
+            ],
+            "strokes": [],
+            "cornerRadius": 4,
+            "cornerSmoothing": 0,
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0.36000001430511475,
+              "g": 0.3973333239555359,
+              "b": 0.4399999976158142,
+              "a": 1
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisAlignItems": "CENTER",
+            "primaryAxisAlignItems": "CENTER",
+            "paddingLeft": 6,
+            "paddingRight": 6,
+            "paddingTop": 2,
+            "paddingBottom": 2,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 10088,
+              "y": 6491,
+              "width": 53,
+              "height": 24
+            },
+            "absoluteRenderBounds": {
+              "x": 10088,
+              "y": 6491,
+              "width": 53,
+              "height": 24
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "HUG",
+            "layoutSizingVertical": "HUG",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:27666",
+            "name": "With new and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 8690,
+              "y": 9679,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 8690,
+              "y": 9679,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "360:37995",
+            "name": "With new and changed",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 8690,
+              "y": 13152,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 8690,
+              "y": 13152,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:27890",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 10190,
+              "y": 9679,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 10190,
+              "y": 9679,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "359:35802",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 10190,
+              "y": 10788,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 10190,
+              "y": 10788,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "360:36424",
+            "name": "Reviewing: 2up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 10190,
+              "y": 11897,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 10190,
+              "y": 11897,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "360:36974",
+            "name": "Reviewing",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 10190,
+              "y": 13152,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 10190,
+              "y": 13152,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "360:38638",
+            "name": "ADE default",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 11690,
+              "y": 13152,
+              "width": 812,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 11690,
+              "y": 13152,
+              "width": 812,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          },
+          {
+            "id": "358:28096",
+            "name": "Reviewing: 1up",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": true,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "layoutMode": "HORIZONTAL",
+            "counterAxisSizingMode": "FIXED",
+            "primaryAxisSizingMode": "FIXED",
+            "strokesIncludedInLayout": true,
+            "layoutWrap": "NO_WRAP",
+            "absoluteBoundingBox": {
+              "x": 11690,
+              "y": 9679,
+              "width": 1400,
+              "height": 970
+            },
+            "absoluteRenderBounds": {
+              "x": 11690,
+              "y": 9679,
+              "width": 1400,
+              "height": 970
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "layoutSizingHorizontal": "FIXED",
+            "layoutSizingVertical": "FIXED",
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "41:3113",
+        "name": "prior art",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "41:6463",
+            "name": "Filters 2.0",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "boundVariables": {
+              "fills": [
+                {
+                  "type": "VARIABLE_ALIAS",
+                  "id": "VariableID:c2b42f4e95ad77909b30a3d20b1f94b85e89351b/2420:37"
+                }
+              ]
+            },
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0.3607843220233917,
+                  "g": 0.40784314274787903,
+                  "b": 0.43921568989753723,
+                  "a": 1
+                },
+                "boundVariables": {
+                  "color": {
+                    "type": "VARIABLE_ALIAS",
+                    "id": "VariableID:c2b42f4e95ad77909b30a3d20b1f94b85e89351b/2420:37"
+                  }
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 12340,
+              "height": 1386
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 12340,
+              "height": 1386
+            },
+            "sectionContentsHidden": false
+          },
+          {
+            "id": "41:14449",
+            "name": "Filters 2.0",
+            "type": "SECTION",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "fills": [
+              {
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 1,
+                  "g": 1,
+                  "b": 1,
+                  "a": 1
+                }
+              }
+            ],
+            "strokes": [
+              {
+                "opacity": 0.10000000149011612,
+                "blendMode": "NORMAL",
+                "type": "SOLID",
+                "color": {
+                  "r": 0,
+                  "g": 0,
+                  "b": 0,
+                  "a": 1
+                }
+              }
+            ],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 1784,
+              "width": 3081,
+              "height": 2277
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 1784,
+              "width": 3081,
+              "height": 2277
+            },
+            "sectionContentsHidden": false
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      },
+      {
+        "id": "3:2191",
+        "name": "thumbnail",
+        "type": "CANVAS",
+        "scrollBehavior": "SCROLLS",
+        "children": [
+          {
+            "id": "164:4573",
+            "name": "Thumbnail",
+            "type": "FRAME",
+            "scrollBehavior": "SCROLLS",
+            "children": [],
+            "blendMode": "PASS_THROUGH",
+            "clipsContent": false,
+            "background": [],
+            "fills": [],
+            "strokes": [],
+            "strokeWeight": 1,
+            "strokeAlign": "INSIDE",
+            "backgroundColor": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            },
+            "absoluteBoundingBox": {
+              "x": 0,
+              "y": 0,
+              "width": 480,
+              "height": 270
+            },
+            "absoluteRenderBounds": {
+              "x": 0,
+              "y": 0,
+              "width": 480,
+              "height": 270
+            },
+            "constraints": {
+              "vertical": "TOP",
+              "horizontal": "LEFT"
+            },
+            "effects": [],
+            "interactions": [],
+            "complexStrokeProperties": {
+              "strokeType": "BASIC"
+            }
+          }
+        ],
+        "backgroundColor": {
+          "r": 0.9607843160629272,
+          "g": 0.9607843160629272,
+          "b": 0.9607843160629272,
+          "a": 1
+        },
+        "prototypeStartNodeID": null,
+        "flowStartingPoints": [],
+        "prototypeDevice": {
+          "type": "NONE",
+          "rotation": "NONE"
+        }
+      }
+    ]
+  },
+  "components": {
+    "359:29728": {
+      "key": "1f5863cd3c59133dbeabe949661d37fa475494b8",
+      "name": "Button",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "48:11165": {
+      "key": "d470412ee8c39058025732e7143429079ae9b804",
+      "name": "Bright=false",
+      "description": "",
+      "remote": true,
+      "componentSetId": "48:11164",
+      "documentationLinks": []
+    },
+    "359:29499": {
+      "key": "7f5fcca03633bd9e98bb6ad5ec635c2dfdda4dc1",
+      "name": "Type=Stock examples",
+      "description": "",
+      "remote": true,
+      "componentSetId": "359:29498",
+      "documentationLinks": []
+    },
+    "359:29500": {
+      "key": "583f7d72622766e3d7375ccbc9693a82e6115268",
+      "name": "Type=Stock examples with warnings",
+      "description": "",
+      "remote": true,
+      "componentSetId": "359:29498",
+      "documentationLinks": []
+    },
+    "53:10297": {
+      "key": "154a6631a86bdec169d2da511919c53a79e0a283",
+      "name": "Tooltip",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "359:29489": {
+      "key": "41f942fbcba723018f34892c5f2aded35bf8266f",
+      "name": "Search",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "54:16144": {
+      "key": "850066f7f158590744fce0d6afc78843b47f2cc4",
+      "name": "Context menu",
+      "description": "",
+      "remote": true,
+      "documentationLinks": []
+    },
+    "54:12460": {
+      "key": "4cc0d3378e7ceea883dcf7ee14b66a939e37a2e0",
+      "name": "Horizontal=False",
+      "description": "",
+      "remote": true,
+      "componentSetId": "54:12459",
+      "documentationLinks": []
+    },
+    "53:10455": {
+      "key": "e34672b9d60d1a2d5d5f9984761fb552f79c6da2",
+      "name": "Variant=Ghost, Size=Small, State=Default",
+      "description": "",
+      "remote": true,
+      "componentSetId": "53:10436",
+      "documentationLinks": []
+    },
+    "53:12780": {
+      "key": "a1c62576d0fe060e560e97031d79b3f926996ef3",
+      "name": "Panel=Controls",
+      "description": "",
+      "remote": true,
+      "componentSetId": "53:12779",
+      "documentationLinks": []
+    }
+  },
+  "componentSets": {
+    "48:11164": {
+      "key": "7870689ba49b152ede3a2f55230692254f1948b0",
+      "name": "Annotation",
+      "description": "",
+      "remote": true
+    },
+    "359:29498": {
+      "key": "11e9f02cc4146c5fd9424b9b88d834a101094fec",
+      "name": "Sidebar",
+      "description": "",
+      "remote": true
+    },
+    "54:12459": {
+      "key": "dd7d60a88aa268b5a6e26e1df3abe9c32bc894b8",
+      "name": "dimension",
+      "description": "",
+      "remote": true
+    },
+    "53:10436": {
+      "key": "cc38453bf78db0972d2044f35ea216bea3f35467",
+      "name": "Button",
+      "description": "Button, Select, Toggle",
+      "remote": true
+    },
+    "53:12779": {
+      "key": "250f8fc98ff5ffd299b8fca4088061093add0b30",
+      "name": "Addon panel",
+      "description": "",
+      "remote": true
+    }
+  },
+  "schemaVersion": 0,
+  "styles": {
+    "41:3845": {
+      "key": "e63db614830d17229fc655efb6b0c9fb66c08eb3",
+      "name": "Popover",
+      "styleType": "EFFECT",
+      "remote": true,
+      "description": ""
+    },
+    "1:3792": {
+      "key": "17ac0c497a8066bb5a440119033f41e359c4ef93",
+      "name": "Monochrome/lightest",
+      "styleType": "FILL",
+      "remote": true,
+      "description": "FFFFFF"
+    },
+    "1:4172": {
+      "key": "f7e5e946d7645f5418783760d1ec4e8f171333af",
+      "name": "Border/dark",
+      "styleType": "FILL",
+      "remote": true,
+      "description": ""
+    }
+  },
+  "name": "Surface new Stories 2026",
+  "lastModified": "2026-06-04T17:58:42Z",
+  "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/cf6416db-c883-4d74-a30d-3a8992e8412b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWCZHCZBGZX%2F20260705%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260705T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=b514c9dc1823f5810aaebd35ada521ec1ba9e08bdc127310d2deff8cf352ed1a",
+  "version": "2361294331249759606",
+  "role": "editor",
+  "editorType": "figma",
+  "linkAccess": "inherit"
+}

--- a/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFile.json
+++ b/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFile.json
@@ -13014,9 +13014,9 @@
   },
   "name": "Surface new Stories 2026",
   "lastModified": "2026-06-04T17:58:42Z",
-  "thumbnailUrl": "https://s3-alpha.figma.com/thumbnails/cf6416db-c883-4d74-a30d-3a8992e8412b?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAQ4GOSFWCZHCZBGZX%2F20260705%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260705T120000Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=b514c9dc1823f5810aaebd35ada521ec1ba9e08bdc127310d2deff8cf352ed1a",
+  "thumbnailUrl": "https://figma-thumbnails.example/redacted",
   "version": "2361294331249759606",
-  "role": "editor",
+  "role": "viewer",
   "editorType": "figma",
   "linkAccess": "inherit"
 }

--- a/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFileComponentSets.json
+++ b/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFileComponentSets.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "component_sets": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFileComponents.json
+++ b/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFileComponents.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "components": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFileStyles.json
+++ b/packages/cuttings/src/__fixtures__/api/surface-new-stories/GetFileStyles.json
@@ -1,0 +1,8 @@
+{
+  "error": false,
+  "status": 200,
+  "meta": {
+    "styles": []
+  },
+  "i18n": null
+}

--- a/packages/cuttings/src/__fixtures__/published.ts
+++ b/packages/cuttings/src/__fixtures__/published.ts
@@ -1,0 +1,67 @@
+import {
+  type PublishedComponent,
+  type PublishedComponentSet,
+  type PublishedStyle,
+  StyleType,
+} from '@figmarine/rest';
+
+import { JeanneDeClisson } from './users';
+
+/**
+ * Published-library API payloads. None of the recorded fixture files
+ * publish components or styles to a team library (their published
+ * endpoints genuinely return empty arrays, which the recorded fixtures
+ * cover), so these spec-typed objects reuse real keys, node ids and names
+ * from the Figma API debug file's in-file component metadata to exercise
+ * the non-empty code paths.
+ */
+export const publishedComponents = [
+  {
+    key: '7f5fcca03633bd9e98bb6ad5ec635c2dfdda4dc1',
+    file_key: 'idLa6ZCXDJUeRFI5wLVNWN',
+    node_id: '2:15696',
+    name: 'Type=Stock examples',
+    description: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    user: JeanneDeClisson,
+  },
+  {
+    key: '5015052a4cb0e58c318f13bbd54f9e2e4a48d4b6',
+    file_key: 'idLa6ZCXDJUeRFI5wLVNWN',
+    node_id: '2:15697',
+    name: 'Type=Custom examples',
+    description: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    user: JeanneDeClisson,
+  },
+] satisfies PublishedComponent[];
+
+export const publishedComponentSets = [
+  {
+    key: '92018a5b8b4e63b7d95d0b9b46e5d43f0e6b8d4e',
+    file_key: 'idLa6ZCXDJUeRFI5wLVNWN',
+    node_id: '2:15695',
+    name: 'Examples',
+    description: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    user: JeanneDeClisson,
+  },
+] satisfies PublishedComponentSet[];
+
+export const publishedStyles = [
+  {
+    key: 'e63db614830d17229fc655efb6b0c9fb66c08eb3',
+    file_key: 'idLa6ZCXDJUeRFI5wLVNWN',
+    node_id: '2:22631',
+    style_type: StyleType.EFFECT,
+    name: 'Popover',
+    description: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    user: JeanneDeClisson,
+    sort_position: 'a',
+  },
+] satisfies PublishedStyle[];

--- a/packages/cuttings/src/__tests__/facet.spec.ts
+++ b/packages/cuttings/src/__tests__/facet.spec.ts
@@ -1,0 +1,36 @@
+import { isFacet } from '../schemas/facet';
+
+/* Logger mock. */
+const { mockedLog } = vi.hoisted(() => ({ mockedLog: vi.fn() }));
+vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
+
+describe('@figmarine/cuttings - facet', () => {
+  describe('isFacet', () => {
+    it('accepts a basic facet', () => {
+      expect(isFacet({ endpoint: 'GetFileStyles', id: 'abc123' })).toBe(true);
+    });
+
+    it('accepts a versioned facet with hydration metadata', () => {
+      expect(
+        isFacet({ endpoint: 'GetFile', id: 'abc123', version: '42', lastHydrated: 123456 }),
+      ).toBe(true);
+    });
+
+    it('tolerates unknown extra fields for forward compatibility', () => {
+      expect(isFacet({ endpoint: 'GetFileStyles', id: 'abc123', version: '42' })).toBe(true);
+    });
+
+    it('rejects unknown endpoints', () => {
+      expect(isFacet({ endpoint: 'GetTeams', id: 'abc123' })).toBe(false);
+    });
+
+    it('rejects facets without an id', () => {
+      expect(isFacet({ endpoint: 'GetFile' })).toBe(false);
+    });
+
+    it('rejects non-object blobs', () => {
+      expect(isFacet('GetFile:abc123')).toBe(false);
+      expect(isFacet(null)).toBe(false);
+    });
+  });
+});

--- a/packages/cuttings/src/__tests__/figmaUrl.spec.ts
+++ b/packages/cuttings/src/__tests__/figmaUrl.spec.ts
@@ -1,0 +1,118 @@
+import { parseFigmaUrl } from '../figmaUrl';
+
+/* Logger mock. */
+const { mockedLog } = vi.hoisted(() => ({ mockedLog: vi.fn() }));
+vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
+
+describe('@figmarine/cuttings - figmaUrl', () => {
+  describe('parseFigmaUrl', () => {
+    it('parses the Figma API debug file URL', () => {
+      expect(
+        parseFigmaUrl(
+          'https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/Steve-s-Figma-API-debug-file?node-id=2-29975&p=f&t=FMV8kjiyTzFwlzs3-0',
+        ),
+      ).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+        name: 'Steve-s-Figma-API-debug-file',
+        nodeId: '2:29975',
+      });
+    });
+
+    it('parses the Error States file URL', () => {
+      expect(
+        parseFigmaUrl(
+          'https://www.figma.com/design/3qv1uKfLSXm4etqj005Rmi/Error-States?node-id=207-48305&p=f&t=TtpPXnNOfDkekQuY-0',
+        ),
+      ).toStrictEqual({
+        fileKey: '3qv1uKfLSXm4etqj005Rmi',
+        name: 'Error-States',
+        nodeId: '207:48305',
+      });
+    });
+
+    it('parses the Surface new Stories file URL', () => {
+      expect(
+        parseFigmaUrl(
+          'https://www.figma.com/design/pMmZ9LmqB0KbgI8GNY4IW9/Surface-new-Stories-2026?node-id=3-2192&p=f&t=KWLFyN6qTdmVpEpW-0',
+        ),
+      ).toStrictEqual({
+        fileKey: 'pMmZ9LmqB0KbgI8GNY4IW9',
+        name: 'Surface-new-Stories-2026',
+        nodeId: '3:2192',
+      });
+    });
+
+    it('parses URLs without a node id or name', () => {
+      expect(parseFigmaUrl('https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN')).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+      });
+    });
+
+    it('parses legacy /file/ URLs', () => {
+      expect(
+        parseFigmaUrl('https://www.figma.com/file/idLa6ZCXDJUeRFI5wLVNWN/Some-Name'),
+      ).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+        name: 'Some-Name',
+      });
+    });
+
+    it('parses FigJam /board/ URLs', () => {
+      expect(
+        parseFigmaUrl('https://www.figma.com/board/idLa6ZCXDJUeRFI5wLVNWN/Some-Board'),
+      ).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+        name: 'Some-Board',
+      });
+    });
+
+    it('parses URLs without the www subdomain', () => {
+      expect(parseFigmaUrl('https://figma.com/design/idLa6ZCXDJUeRFI5wLVNWN')).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+      });
+    });
+
+    it('resolves branch URLs to the branch key', () => {
+      expect(
+        parseFigmaUrl(
+          'https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/branch/aBcD1234eFgH/Steve-s-Figma-API-debug-file',
+        ),
+      ).toStrictEqual({
+        fileKey: 'aBcD1234eFgH',
+        mainFileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+        name: 'Steve-s-Figma-API-debug-file',
+      });
+    });
+
+    it('decodes percent-encoded file names', () => {
+      expect(
+        parseFigmaUrl('https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/D%C3%A9tresse'),
+      ).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+        name: 'Détresse',
+      });
+    });
+
+    it('rejects non-URL input', () => {
+      expect(() => parseFigmaUrl('idLa6ZCXDJUeRFI5wLVNWN')).toThrowError('not a valid URL');
+    });
+
+    it('rejects non-Figma hosts', () => {
+      expect(() =>
+        parseFigmaUrl('https://www.figma.com.evil.example/design/idLa6ZCXDJUeRFI5wLVNWN'),
+      ).toThrowError('not a Figma URL');
+    });
+
+    it('rejects Figma URLs that do not point at files', () => {
+      expect(() => parseFigmaUrl('https://www.figma.com/files/recents-and-sharing')).toThrowError(
+        'not a Figma file URL',
+      );
+    });
+
+    it('rejects file URLs with an invalid key', () => {
+      expect(() => parseFigmaUrl('https://www.figma.com/design/no%20key%20here/Name')).toThrowError(
+        'not a Figma file URL',
+      );
+    });
+  });
+});

--- a/packages/cuttings/src/__tests__/figmaUrl.spec.ts
+++ b/packages/cuttings/src/__tests__/figmaUrl.spec.ts
@@ -42,6 +42,36 @@ describe('@figmarine/cuttings - figmaUrl', () => {
       });
     });
 
+    it('normalises instance-path node ids with several dashes', () => {
+      expect(
+        parseFigmaUrl(
+          'https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/Name?node-id=I2005-6797%3B2005-6798',
+        ).nodeId,
+      ).toBe('I2005:6797;2005:6798');
+    });
+
+    it('parses prototype URLs', () => {
+      expect(
+        parseFigmaUrl('https://www.figma.com/proto/idLa6ZCXDJUeRFI5wLVNWN/My-Proto?node-id=1-2'),
+      ).toStrictEqual({
+        fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',
+        name: 'My-Proto',
+        nodeId: '1:2',
+      });
+    });
+
+    it('keeps undecodable name slugs raw instead of throwing', () => {
+      expect(
+        parseFigmaUrl('https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/100%-off').name,
+      ).toBe('100%-off');
+    });
+
+    it('rejects branch URLs with an invalid branch key', () => {
+      expect(() =>
+        parseFigmaUrl('https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/branch/not%20a%20key/N'),
+      ).toThrowError('not a Figma file URL');
+    });
+
     it('parses URLs without a node id or name', () => {
       expect(parseFigmaUrl('https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN')).toStrictEqual({
         fileKey: 'idLa6ZCXDJUeRFI5wLVNWN',

--- a/packages/cuttings/src/__tests__/fs.spec.ts
+++ b/packages/cuttings/src/__tests__/fs.spec.ts
@@ -92,6 +92,32 @@ describe('@figmarine/cuttings - fs', () => {
       expect(mockedLog).toHaveBeenCalledWith(expect.stringMatching(/overwriting existing file/));
     });
 
+    it('leaves the file untouched when only timestamps changed', ({
+      fileBasic,
+      fileBasicLocation,
+    }) => {
+      plantCutting(fileBasic, fileBasicLocation);
+      const firstWrite = vol.readFileSync(fileBasicLocation, 'utf8');
+
+      const rehydrated = structuredClone(fileBasic);
+      rehydrated.facets = rehydrated.facets.map((f) => ({ ...f, lastHydrated: 999999999 }));
+      plantCutting(rehydrated, fileBasicLocation);
+
+      expect(vol.readFileSync(fileBasicLocation, 'utf8')).toStrictEqual(firstWrite);
+      expect(mockedLog).toHaveBeenCalledWith(expect.stringMatching(/content unchanged/));
+    });
+
+    it('overwrites the file when content changed', ({ fileBasic, fileBasicLocation }) => {
+      plantCutting(fileBasic, fileBasicLocation);
+
+      const changed = structuredClone(fileBasic);
+      changed.data.files.naoned.version = '45';
+      plantCutting(changed, fileBasicLocation);
+
+      const written = JSON.parse(vol.readFileSync(fileBasicLocation, 'utf8').toString());
+      expect(written.data.files.naoned.version).toBe('45');
+    });
+
     it('does not write `lastKnownFilePath` to a stored cutting', ({
       fileBasic,
       fileBasicLocation,

--- a/packages/cuttings/src/__tests__/fs.spec.ts
+++ b/packages/cuttings/src/__tests__/fs.spec.ts
@@ -57,7 +57,7 @@ describe('@figmarine/cuttings - fs', () => {
 
       const written = vol.readFileSync(fileBasicLocation, 'utf8');
       expect(written).toBeDefined();
-      expect(written).toContain(`"label":"${fileBasic.meta.label}"`);
+      expect(written).toContain(`"label": "${fileBasic.meta.label}"`);
     });
 
     it('creates the folders where to write if required, and warns about it', ({
@@ -68,7 +68,7 @@ describe('@figmarine/cuttings - fs', () => {
 
       const written = vol.readFileSync(fileBasicLocation, 'utf8');
       expect(written).toBeDefined();
-      expect(written).toContain(`"label":"${fileBasic.meta.label}"`);
+      expect(written).toContain(`"label": "${fileBasic.meta.label}"`);
       expect(mockedLog).toHaveBeenCalledWith(
         expect.stringMatching(/directory .* does not exist, attempting to create/),
       );
@@ -88,7 +88,7 @@ describe('@figmarine/cuttings - fs', () => {
       const written = vol.readFileSync(fileBasicLocation, 'utf8');
       expect(written).toBeDefined();
       expect(written).not.toBe(priorFileContent);
-      expect(written).toContain(`"label":"${fileBasic.meta.label}"`);
+      expect(written).toContain(`"label": "${fileBasic.meta.label}"`);
       expect(mockedLog).toHaveBeenCalledWith(expect.stringMatching(/overwriting existing file/));
     });
 

--- a/packages/cuttings/src/__tests__/hydrate.spec.ts
+++ b/packages/cuttings/src/__tests__/hydrate.spec.ts
@@ -82,6 +82,8 @@ describe('@figmarine/cuttings - hydrate', () => {
   });
 
   it('bumps each facet hydration timestamp', async ({ client, cutting }) => {
+    // The cutting fixture moves the clock to TAKE_TIME while building.
+    vi.setSystemTime(HYDRATE_TIME);
     const hydrated = await hydrate({ client, cutting });
 
     expect(hydrated.facets).toHaveLength(2);

--- a/packages/cuttings/src/__tests__/hydrate.spec.ts
+++ b/packages/cuttings/src/__tests__/hydrate.spec.ts
@@ -1,0 +1,108 @@
+import type { ClientInterface, V1 } from '@figmarine/rest';
+import { test as base } from 'vitest';
+
+import { API_FIXTURE_FILES, loadApiFixture } from '../__fixtures__/api';
+import type { Cutting } from '../schemas/cutting';
+import { hydrate } from '../hydrate';
+import { take } from '../take';
+
+/* Logger mock. */
+const { mockedLog } = vi.hoisted(() => ({ mockedLog: vi.fn() }));
+vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
+
+const FILE_KEY = API_FIXTURE_FILES['figma-api-debug-file'];
+const TAKE_TIME = 1751791000000;
+const HYDRATE_TIME = 1751795000000;
+
+function mockResponse<T>(data: T) {
+  return { status: 200, statusText: 'OK', data };
+}
+
+interface HydrateFixtures {
+  client: ClientInterface;
+  cutting: Cutting;
+}
+const it = base.extend<HydrateFixtures>({
+  client: async ({}, use) => {
+    await use({
+      v1: {
+        getFile: vi.fn(async () => mockResponse(loadApiFixture('figma-api-debug-file', 'GetFile'))),
+        getFileStyles: vi.fn(async () =>
+          mockResponse(loadApiFixture('figma-api-debug-file', 'GetFileStyles')),
+        ),
+      },
+    } as unknown as ClientInterface);
+  },
+  cutting: async ({ client }, use) => {
+    vi.setSystemTime(TAKE_TIME);
+    const cutting = await take({
+      client,
+      facets: [
+        { endpoint: 'GetFile', id: FILE_KEY },
+        { endpoint: 'GetFileStyles', id: FILE_KEY },
+      ],
+      label: 'debug file',
+    });
+    cutting.meta.lastStored = TAKE_TIME;
+    cutting.meta.lastKnownFilePath = '/somewhere/debug.cutting.figmarine.json';
+    await use(cutting);
+  },
+});
+
+describe('@figmarine/cuttings - hydrate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(HYDRATE_TIME);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('refetches every facet of the cutting', async ({ client, cutting }) => {
+    await hydrate({ client, cutting });
+
+    expect(client.v1.getFile).toHaveBeenCalledTimes(2);
+    expect(client.v1.getFileStyles).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates the data with fresh API responses', async ({ client, cutting }) => {
+    const freshFile = {
+      ...loadApiFixture<V1.GetFile.ResponseBody>('figma-api-debug-file', 'GetFile'),
+      version: 'fresher-than-fresh',
+    };
+    vi.mocked(client.v1.getFile).mockResolvedValueOnce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockResponse(freshFile) as any,
+    );
+
+    const hydrated = await hydrate({ client, cutting });
+
+    expect(hydrated.data.files[FILE_KEY].version).toBe('fresher-than-fresh');
+  });
+
+  it('bumps each facet hydration timestamp', async ({ client, cutting }) => {
+    const hydrated = await hydrate({ client, cutting });
+
+    expect(hydrated.facets).toHaveLength(2);
+    for (const facet of hydrated.facets) {
+      expect(facet.lastHydrated).toBe(HYDRATE_TIME);
+    }
+  });
+
+  it('preserves storage metadata so the cutting can be replanted', async ({ client, cutting }) => {
+    const hydrated = await hydrate({ client, cutting });
+
+    expect(hydrated.meta.label).toBe(cutting.meta.label);
+    expect(hydrated.meta.lastStored).toBe(TAKE_TIME);
+    expect(hydrated.meta.lastKnownFilePath).toBe(cutting.meta.lastKnownFilePath);
+  });
+
+  it('does not mutate the original cutting', async ({ client, cutting }) => {
+    const before = structuredClone(cutting);
+
+    await hydrate({ client, cutting });
+
+    expect(cutting).toStrictEqual(before);
+  });
+});

--- a/packages/cuttings/src/__tests__/index.spec.ts
+++ b/packages/cuttings/src/__tests__/index.spec.ts
@@ -11,5 +11,6 @@ describe('@figmarine/cuttings - index', () => {
     expect(index.slimFile).toBeDefined();
     expect(index.isCutting).toBeDefined();
     expect(index.isFacet).toBeDefined();
+    expect(index.printZodError).toBeDefined();
   });
 });

--- a/packages/cuttings/src/__tests__/index.spec.ts
+++ b/packages/cuttings/src/__tests__/index.spec.ts
@@ -1,10 +1,15 @@
 import * as index from '../index';
 
 describe('@figmarine/cuttings - index', () => {
-  it('exports something', () => {
+  it('exports the cutting lifecycle API', () => {
     expect(index).toBeDefined();
     expect(index.take).toBeDefined();
+    expect(index.hydrate).toBeDefined();
     expect(index.digCutting).toBeDefined();
     expect(index.plantCutting).toBeDefined();
+    expect(index.parseFigmaUrl).toBeDefined();
+    expect(index.slimFile).toBeDefined();
+    expect(index.isCutting).toBeDefined();
+    expect(index.isFacet).toBeDefined();
   });
 });

--- a/packages/cuttings/src/__tests__/logHelpers.spec.ts
+++ b/packages/cuttings/src/__tests__/logHelpers.spec.ts
@@ -1,9 +1,9 @@
 import { test as base } from 'vitest';
 import { vol } from 'memfs';
 
+import { type Cutting, CuttingSchema } from '../schemas/cutting';
 import { fileBasic, unlabeled, unstoredAndUnlabeled } from '../__fixtures__/cuttings';
-import { printCutting, printFacet, printFacets } from '../logHelpers';
-import type { Cutting } from '../schemas/cutting';
+import { printCutting, printFacet, printFacets, printZodError } from '../logHelpers';
 
 /* FS mocks. */
 vi.mock('node:fs');
@@ -71,6 +71,27 @@ describe('@figmarine/cuttings - logHelpers', () => {
       expect(allFacets).toContain(f0);
       expect(allFacets).toContain(f1);
       expect(allFacets.indexOf(f0)).toBeLessThan(allFacets.indexOf(f1));
+    });
+  });
+
+  describe('printZodError', () => {
+    it('prints one line per issue with its path', () => {
+      const outcome = CuttingSchema.safeParse({ meta: {}, facets: 'not-an-array' });
+      expect(outcome.success).toBe(false);
+
+      const printed = printZodError(outcome.error!);
+      const lines = printed.split('\n');
+
+      expect(lines.length).toBe(outcome.error!.issues.length);
+      expect(printed).toContain('meta.lastStored');
+      expect(printed).toContain('facets');
+    });
+
+    it('labels issues without a path as <root>', () => {
+      const outcome = CuttingSchema.safeParse('not even an object');
+      expect(outcome.success).toBe(false);
+
+      expect(printZodError(outcome.error!)).toContain('<root>');
     });
   });
 });

--- a/packages/cuttings/src/__tests__/slim.spec.ts
+++ b/packages/cuttings/src/__tests__/slim.spec.ts
@@ -1,0 +1,45 @@
+import type { V1 } from '@figmarine/rest';
+
+import { loadApiFixture } from '../__fixtures__/api';
+import { slimFile } from '../slim';
+
+describe('@figmarine/cuttings - slim', () => {
+  describe('slimFile', () => {
+    const body = loadApiFixture<V1.GetFile.ResponseBody>('figma-api-debug-file', 'GetFile');
+
+    it('keeps the fields needed for offline analysis', () => {
+      const slim = slimFile(body);
+
+      expect(slim.name).toBe(body.name);
+      expect(slim.lastModified).toBe(body.lastModified);
+      expect(slim.editorType).toBe(body.editorType);
+      expect(slim.version).toBe(body.version);
+      expect(slim.schemaVersion).toBe(body.schemaVersion);
+      expect(slim.document).toStrictEqual(body.document);
+      expect(slim.components).toStrictEqual(body.components);
+      expect(slim.componentSets).toStrictEqual(body.componentSets);
+      expect(slim.styles).toStrictEqual(body.styles);
+    });
+
+    it('drops volatile and access-related fields', () => {
+      const slim = slimFile(body) as Record<string, unknown>;
+
+      expect(slim.thumbnailUrl).toBeUndefined();
+      expect(slim.role).toBeUndefined();
+      expect(slim.linkAccess).toBeUndefined();
+    });
+
+    it('omits optional fields that the response does not contain', () => {
+      const { branches: _branches, ...withoutBranches } = body;
+      const slim = slimFile(withoutBranches as V1.GetFile.ResponseBody);
+
+      expect('branches' in slim).toBe(false);
+    });
+
+    it('round-trips through JSON without loss', () => {
+      const slim = slimFile(body);
+
+      expect(JSON.parse(JSON.stringify(slim))).toStrictEqual(slim);
+    });
+  });
+});

--- a/packages/cuttings/src/__tests__/slim.spec.ts
+++ b/packages/cuttings/src/__tests__/slim.spec.ts
@@ -29,6 +29,26 @@ describe('@figmarine/cuttings - slim', () => {
       expect(slim.linkAccess).toBeUndefined();
     });
 
+    it('drops volatile thumbnail URLs from branch entries', () => {
+      const withBranches = {
+        ...body,
+        branches: [
+          {
+            key: 'branchKey123',
+            name: 'A branch',
+            thumbnail_url: 'https://s3.example/signed?X-Amz-Signature=abc',
+            last_modified: '2026-07-01T00:00:00Z',
+          },
+        ],
+      } as V1.GetFile.ResponseBody;
+
+      const slim = slimFile(withBranches);
+
+      expect(slim.branches).toStrictEqual([
+        { key: 'branchKey123', name: 'A branch', last_modified: '2026-07-01T00:00:00Z' },
+      ]);
+    });
+
     it('omits optional fields that the response does not contain', () => {
       const { branches: _branches, ...withoutBranches } = body;
       const slim = slimFile(withoutBranches as V1.GetFile.ResponseBody);

--- a/packages/cuttings/src/__tests__/take.spec.ts
+++ b/packages/cuttings/src/__tests__/take.spec.ts
@@ -1,0 +1,223 @@
+import type { ClientInterface, V1 } from '@figmarine/rest';
+import { test as base } from 'vitest';
+
+import { API_FIXTURE_FILES, loadApiFixture } from '../__fixtures__/api';
+import { isCutting } from '../schemas/cutting';
+import { slimFile } from '../slim';
+import { take } from '../take';
+
+/* Logger mock. */
+const { mockedLog } = vi.hoisted(() => ({ mockedLog: vi.fn() }));
+vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
+
+const FILE_KEY = API_FIXTURE_FILES['figma-api-debug-file'];
+const NOW = 1751791000000;
+
+/* Test fixtures: a REST client mocked with real recorded API responses. */
+function mockResponse<T>(data: T) {
+  return { status: 200, statusText: 'OK', data };
+}
+
+function makeMockedClient(label: keyof typeof API_FIXTURE_FILES = 'figma-api-debug-file') {
+  return {
+    v1: {
+      getFile: vi.fn(async () => mockResponse(loadApiFixture(label, 'GetFile'))),
+      getFileComponents: vi.fn(async () =>
+        mockResponse(loadApiFixture(label, 'GetFileComponents')),
+      ),
+      getFileComponentSets: vi.fn(async () =>
+        mockResponse(loadApiFixture(label, 'GetFileComponentSets')),
+      ),
+      getFileStyles: vi.fn(async () => mockResponse(loadApiFixture(label, 'GetFileStyles'))),
+    },
+  } as unknown as ClientInterface;
+}
+
+interface TakeFixtures {
+  client: ClientInterface;
+}
+const it = base.extend<TakeFixtures>({
+  client: async ({}, use) => {
+    await use(makeMockedClient());
+  },
+});
+
+describe('@figmarine/cuttings - take', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('GetFile facets', () => {
+    it('stores the file under its file key', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY }],
+        label: 'debug file',
+      });
+
+      const raw = loadApiFixture<V1.GetFile.ResponseBody>('figma-api-debug-file', 'GetFile');
+      expect(Object.keys(cutting.data.files)).toStrictEqual([FILE_KEY]);
+      expect(cutting.data.files[FILE_KEY]).toStrictEqual(slimFile(raw));
+    });
+
+    it('slims volatile fields out of the stored file', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY }],
+      });
+
+      const stored = cutting.data.files[FILE_KEY] as Record<string, unknown>;
+      expect(stored.thumbnailUrl).toBeUndefined();
+      expect(stored.role).toBeUndefined();
+    });
+
+    it('requests branch data and forwards the facet version', async ({ client }) => {
+      await take({
+        client,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY, version: '42' }],
+      });
+
+      expect(client.v1.getFile).toHaveBeenCalledExactlyOnceWith(FILE_KEY, {
+        branch_data: true,
+        version: '42',
+      });
+    });
+  });
+
+  describe('GetFileComponents facets', () => {
+    it('stores published components under their component key', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFileComponents', id: FILE_KEY }],
+      });
+
+      const raw = loadApiFixture<{ meta: { components: { key: string }[] } }>(
+        'figma-api-debug-file',
+        'GetFileComponents',
+      );
+      expect(Object.keys(cutting.data.components).sort()).toStrictEqual(
+        raw.meta.components.map((c) => c.key).sort(),
+      );
+    });
+  });
+
+  describe('GetFileComponentSets facets', () => {
+    it('stores published component sets under their key', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFileComponentSets', id: FILE_KEY }],
+      });
+
+      const raw = loadApiFixture<{ meta: { component_sets: { key: string }[] } }>(
+        'figma-api-debug-file',
+        'GetFileComponentSets',
+      );
+      expect(Object.keys(cutting.data.componentSets).sort()).toStrictEqual(
+        raw.meta.component_sets.map((c) => c.key).sort(),
+      );
+    });
+  });
+
+  describe('GetFileStyles facets', () => {
+    it('stores published styles under their key', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFileStyles', id: FILE_KEY }],
+      });
+
+      const raw = loadApiFixture<{ meta: { styles: { key: string }[] } }>(
+        'figma-api-debug-file',
+        'GetFileStyles',
+      );
+      expect(Object.keys(cutting.data.styles).sort()).toStrictEqual(
+        raw.meta.styles.map((s) => s.key).sort(),
+      );
+    });
+  });
+
+  describe('whole cuttings', () => {
+    it('combines multiple facets into one valid cutting', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [
+          { endpoint: 'GetFile', id: FILE_KEY },
+          { endpoint: 'GetFileComponents', id: FILE_KEY },
+          { endpoint: 'GetFileComponentSets', id: FILE_KEY },
+          { endpoint: 'GetFileStyles', id: FILE_KEY },
+        ],
+        label: 'debug file',
+      });
+
+      expect(cutting.meta.label).toBe('debug file');
+      expect(cutting.meta.figmarineVersion).toBe(0);
+      expect(cutting.meta.lastStored).toBe(0);
+      expect(cutting.facets).toHaveLength(4);
+      expect(isCutting(JSON.parse(JSON.stringify(cutting)))).toBe(true);
+    });
+
+    it('records when each facet was hydrated', async ({ client }) => {
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY }],
+      });
+
+      expect(cutting.facets[0].lastHydrated).toBe(NOW);
+    });
+
+    it('supports data from several files in one cutting', async ({ client }) => {
+      const otherKey = API_FIXTURE_FILES['error-states'];
+      const cutting = await take({
+        client,
+        facets: [
+          { endpoint: 'GetFile', id: FILE_KEY },
+          { endpoint: 'GetFile', id: otherKey },
+        ],
+      });
+
+      expect(Object.keys(cutting.data.files).sort()).toStrictEqual([FILE_KEY, otherKey].sort());
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on unimplemented endpoint types', async ({ client }) => {
+      await expect(() =>
+        take({
+          client,
+          facets: [{ endpoint: 'GetTeamComponents', id: '12345' }],
+        }),
+      ).rejects.toThrowError('endpoint type GetTeamComponents is not implemented yet');
+    });
+
+    it('throws when a facet request does not succeed', async ({ client }) => {
+      vi.mocked(client.v1.getFile).mockResolvedValueOnce({
+        status: 404,
+        statusText: 'Not Found',
+        data: {},
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
+
+      await expect(() =>
+        take({
+          client,
+          facets: [{ endpoint: 'GetFile', id: 'missing' }],
+        }),
+      ).rejects.toThrowError('network call failed for facet GetFile:missing. 404: Not Found');
+    });
+
+    it('propagates client rejections', async ({ client }) => {
+      vi.mocked(client.v1.getFile).mockRejectedValueOnce(new Error('boom'));
+
+      await expect(() =>
+        take({
+          client,
+          facets: [{ endpoint: 'GetFile', id: FILE_KEY }],
+        }),
+      ).rejects.toThrowError('boom');
+    });
+  });
+});

--- a/packages/cuttings/src/__tests__/take.spec.ts
+++ b/packages/cuttings/src/__tests__/take.spec.ts
@@ -2,6 +2,11 @@ import type { ClientInterface, V1 } from '@figmarine/rest';
 import { test as base } from 'vitest';
 
 import { API_FIXTURE_FILES, loadApiFixture } from '../__fixtures__/api';
+import {
+  publishedComponents,
+  publishedComponentSets,
+  publishedStyles,
+} from '../__fixtures__/published';
 import { isCutting } from '../schemas/cutting';
 import { slimFile } from '../slim';
 import { take } from '../take';
@@ -90,53 +95,68 @@ describe('@figmarine/cuttings - take', () => {
   });
 
   describe('GetFileComponents facets', () => {
-    it('stores published components under their component key', async ({ client }) => {
+    it('leaves the component map empty when the file publishes none', async ({ client }) => {
+      // The recorded fixtures publish nothing; this is the real response.
       const cutting = await take({
         client,
         facets: [{ endpoint: 'GetFileComponents', id: FILE_KEY }],
       });
 
-      const raw = loadApiFixture<{ meta: { components: { key: string }[] } }>(
-        'figma-api-debug-file',
-        'GetFileComponents',
+      expect(cutting.data.components).toStrictEqual({});
+    });
+
+    it('stores published components under their component key', async ({ client }) => {
+      vi.mocked(client.v1.getFileComponents).mockResolvedValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockResponse({ meta: { components: publishedComponents } }) as any,
       );
+
+      const cutting = await take({
+        client,
+        facets: [{ endpoint: 'GetFileComponents', id: FILE_KEY }],
+      });
+
       expect(Object.keys(cutting.data.components).sort()).toStrictEqual(
-        raw.meta.components.map((c) => c.key).sort(),
+        publishedComponents.map((c) => c.key).sort(),
+      );
+      expect(cutting.data.components[publishedComponents[0].key]).toStrictEqual(
+        publishedComponents[0],
       );
     });
   });
 
   describe('GetFileComponentSets facets', () => {
     it('stores published component sets under their key', async ({ client }) => {
+      vi.mocked(client.v1.getFileComponentSets).mockResolvedValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockResponse({ meta: { component_sets: publishedComponentSets } }) as any,
+      );
+
       const cutting = await take({
         client,
         facets: [{ endpoint: 'GetFileComponentSets', id: FILE_KEY }],
       });
 
-      const raw = loadApiFixture<{ meta: { component_sets: { key: string }[] } }>(
-        'figma-api-debug-file',
-        'GetFileComponentSets',
-      );
-      expect(Object.keys(cutting.data.componentSets).sort()).toStrictEqual(
-        raw.meta.component_sets.map((c) => c.key).sort(),
+      expect(Object.keys(cutting.data.componentSets)).toStrictEqual(
+        publishedComponentSets.map((c) => c.key),
       );
     });
   });
 
   describe('GetFileStyles facets', () => {
     it('stores published styles under their key', async ({ client }) => {
+      vi.mocked(client.v1.getFileStyles).mockResolvedValueOnce(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockResponse({ meta: { styles: publishedStyles } }) as any,
+      );
+
       const cutting = await take({
         client,
         facets: [{ endpoint: 'GetFileStyles', id: FILE_KEY }],
       });
 
-      const raw = loadApiFixture<{ meta: { styles: { key: string }[] } }>(
-        'figma-api-debug-file',
-        'GetFileStyles',
-      );
-      expect(Object.keys(cutting.data.styles).sort()).toStrictEqual(
-        raw.meta.styles.map((s) => s.key).sort(),
-      );
+      expect(Object.keys(cutting.data.styles)).toStrictEqual(publishedStyles.map((s) => s.key));
+      expect(cutting.data.styles[publishedStyles[0].key].style_type).toBe('EFFECT');
     });
   });
 
@@ -193,21 +213,30 @@ describe('@figmarine/cuttings - take', () => {
       ).rejects.toThrowError('endpoint type GetTeamComponents is not implemented yet');
     });
 
-    it('throws when a facet request does not succeed', async ({ client }) => {
-      vi.mocked(client.v1.getFile).mockResolvedValueOnce({
-        status: 404,
-        statusText: 'Not Found',
-        data: {},
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+    const ERROR_CASES = [
+      ['GetFile', 'getFile'],
+      ['GetFileComponents', 'getFileComponents'],
+      ['GetFileComponentSets', 'getFileComponentSets'],
+      ['GetFileStyles', 'getFileStyles'],
+    ] as const;
+    for (const [endpoint, method] of ERROR_CASES) {
+      it(`throws when a ${endpoint} request does not succeed`, async () => {
+        const client = makeMockedClient();
+        vi.mocked(client.v1[method]).mockResolvedValueOnce({
+          status: 404,
+          statusText: 'Not Found',
+          data: {},
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
 
-      await expect(() =>
-        take({
-          client,
-          facets: [{ endpoint: 'GetFile', id: 'missing' }],
-        }),
-      ).rejects.toThrowError('network call failed for facet GetFile:missing. 404: Not Found');
-    });
+        await expect(() =>
+          take({
+            client,
+            facets: [{ endpoint, id: 'missing' }],
+          }),
+        ).rejects.toThrowError(`network call failed for facet ${endpoint}:missing. 404: Not Found`);
+      });
+    }
 
     it('propagates client rejections', async ({ client }) => {
       vi.mocked(client.v1.getFile).mockRejectedValueOnce(new Error('boom'));

--- a/packages/cuttings/src/figmaUrl.ts
+++ b/packages/cuttings/src/figmaUrl.ts
@@ -17,7 +17,8 @@ export interface FigmaFileRef {
 
   /**
    * The node targeted by the URL's `node-id` query parameter, if any,
-   * normalised to the API format (e.g. `12:345`).
+   * normalised to the API format (e.g. `12:345`, or `I12:345;67:890` for
+   * nodes nested inside instances).
    */
   nodeId?: string;
 
@@ -28,12 +29,26 @@ export interface FigmaFileRef {
 }
 
 const FIGMA_HOSTS = ['figma.com', 'www.figma.com'];
-const FILE_PATH_KINDS = ['design', 'file', 'board', 'slides', 'make', 'site'];
+const FILE_PATH_KINDS = ['design', 'file', 'board', 'slides', 'make', 'site', 'proto', 'deck'];
+const FILE_KEY_PATTERN = /^[A-Za-z0-9]+$/;
+
+/**
+ * Decodes a URL path segment, falling back to the raw segment when it
+ * contains stray percent signs (the WHATWG URL parser tolerates them).
+ */
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
 
 /**
  * Parses a URL to a Figma file into the identifiers needed to fetch that
  * file over the REST API. Supports current `/design/`, legacy `/file/`,
- * FigJam `/board/` and other file-kind URLs, as well as branch URLs.
+ * FigJam `/board/`, prototype `/proto/` and other file-kind URLs, as well
+ * as branch URLs.
  *
  * @param url The URL to parse.
  * @throws When the URL is not a valid Figma file URL.
@@ -56,25 +71,28 @@ export function parseFigmaUrl(url: string): FigmaFileRef {
   const segments = parsed.pathname.split('/').filter(Boolean);
   const [kind, fileKey, ...rest] = segments;
 
-  if (!kind || !FILE_PATH_KINDS.includes(kind) || !fileKey || !/^[A-Za-z0-9]+$/.test(fileKey)) {
+  if (!kind || !FILE_PATH_KINDS.includes(kind) || !fileKey || !FILE_KEY_PATTERN.test(fileKey)) {
     throw new Error(`Cuttings::parseFigmaUrl: not a Figma file URL: '${url}'.`);
   }
 
   const ref: FigmaFileRef = { fileKey };
 
-  if (rest[0] === 'branch' && rest[1]) {
+  if (rest[0] === 'branch') {
+    if (!rest[1] || !FILE_KEY_PATTERN.test(rest[1])) {
+      throw new Error(`Cuttings::parseFigmaUrl: not a Figma file URL: '${url}'.`);
+    }
     ref.mainFileKey = fileKey;
     ref.fileKey = rest[1];
     if (rest[2]) {
-      ref.name = decodeURIComponent(rest[2]);
+      ref.name = safeDecode(rest[2]);
     }
   } else if (rest[0]) {
-    ref.name = decodeURIComponent(rest[0]);
+    ref.name = safeDecode(rest[0]);
   }
 
   const nodeId = parsed.searchParams.get('node-id');
   if (nodeId) {
-    ref.nodeId = nodeId.replace(/-/, ':');
+    ref.nodeId = nodeId.replace(/-/g, ':');
   }
 
   log(`Cuttings::parseFigmaUrl: found file key '${ref.fileKey}'.`);

--- a/packages/cuttings/src/figmaUrl.ts
+++ b/packages/cuttings/src/figmaUrl.ts
@@ -1,0 +1,83 @@
+import { log } from '@figmarine/logger';
+
+/**
+ * A reference to a Figma file, extracted from a URL to that file.
+ */
+export interface FigmaFileRef {
+  /**
+   * The key to pass to file-scoped REST API endpoints. When the URL points
+   * at a branch, this is the branch's own key.
+   */
+  fileKey: string;
+
+  /**
+   * The key of the main file, when the URL points at a branch of it.
+   */
+  mainFileKey?: string;
+
+  /**
+   * The node targeted by the URL's `node-id` query parameter, if any,
+   * normalised to the API format (e.g. `12:345`).
+   */
+  nodeId?: string;
+
+  /**
+   * The URL slug of the file name, if present (e.g. `My-Design-File`).
+   */
+  name?: string;
+}
+
+const FIGMA_HOSTS = ['figma.com', 'www.figma.com'];
+const FILE_PATH_KINDS = ['design', 'file', 'board', 'slides', 'make', 'site'];
+
+/**
+ * Parses a URL to a Figma file into the identifiers needed to fetch that
+ * file over the REST API. Supports current `/design/`, legacy `/file/`,
+ * FigJam `/board/` and other file-kind URLs, as well as branch URLs.
+ *
+ * @param url The URL to parse.
+ * @throws When the URL is not a valid Figma file URL.
+ * @returns The extracted {@link FigmaFileRef}.
+ */
+export function parseFigmaUrl(url: string): FigmaFileRef {
+  log(`Cuttings::parseFigmaUrl: parsing '${url}'.`);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Cuttings::parseFigmaUrl: not a valid URL: '${url}'.`);
+  }
+
+  if (!FIGMA_HOSTS.includes(parsed.hostname)) {
+    throw new Error(`Cuttings::parseFigmaUrl: not a Figma URL: '${url}'.`);
+  }
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  const [kind, fileKey, ...rest] = segments;
+
+  if (!kind || !FILE_PATH_KINDS.includes(kind) || !fileKey || !/^[A-Za-z0-9]+$/.test(fileKey)) {
+    throw new Error(`Cuttings::parseFigmaUrl: not a Figma file URL: '${url}'.`);
+  }
+
+  const ref: FigmaFileRef = { fileKey };
+
+  if (rest[0] === 'branch' && rest[1]) {
+    ref.mainFileKey = fileKey;
+    ref.fileKey = rest[1];
+    if (rest[2]) {
+      ref.name = decodeURIComponent(rest[2]);
+    }
+  } else if (rest[0]) {
+    ref.name = decodeURIComponent(rest[0]);
+  }
+
+  const nodeId = parsed.searchParams.get('node-id');
+  if (nodeId) {
+    ref.nodeId = nodeId.replace(/-/, ':');
+  }
+
+  log(`Cuttings::parseFigmaUrl: found file key '${ref.fileKey}'.`);
+
+  return ref;
+}

--- a/packages/cuttings/src/fs.ts
+++ b/packages/cuttings/src/fs.ts
@@ -6,7 +6,9 @@ import { log } from '@figmarine/logger';
 import { type Cutting, isCutting } from './schemas/cutting';
 
 function stringifyCutting(cutting: Cutting): string {
-  return JSON.stringify(cutting);
+  // Cuttings are meant to be committed to consumer repositories, so
+  // pretty-print them for reviewable diffs.
+  return `${JSON.stringify(cutting, null, 2)}\n`;
 }
 
 function parseCuttingString(str: string): Cutting {

--- a/packages/cuttings/src/fs.ts
+++ b/packages/cuttings/src/fs.ts
@@ -11,6 +11,19 @@ function stringifyCutting(cutting: Cutting): string {
   return `${JSON.stringify(cutting, null, 2)}\n`;
 }
 
+/**
+ * Serialises the parts of a cutting that describe Figma content, leaving
+ * out write and hydration timestamps. Two cuttings with equal content
+ * should not produce a diff when replanted.
+ */
+function contentFingerprint(cutting: Cutting): string {
+  return JSON.stringify({
+    label: cutting.meta.label,
+    facets: cutting.facets.map(({ lastHydrated: _lastHydrated, ...facet }) => facet),
+    data: cutting.data,
+  });
+}
+
 function parseCuttingString(str: string): Cutting {
   return JSON.parse(str);
 }
@@ -29,6 +42,18 @@ export function plantCutting(cutting: Cutting, location: string): void {
   }
 
   if (fs.existsSync(location)) {
+    // Keep committed cuttings diff-stable: when only timestamps would
+    // change, leave the planted file untouched so refresh loops stay
+    // quiet and reviewable diffs only ever contain content changes.
+    try {
+      const existing = JSON.parse(fs.readFileSync(location, 'utf-8')) as Cutting;
+      if (contentFingerprint(existing) === contentFingerprint(cutting)) {
+        log(`Cuttings::plantCutting: content unchanged, leaving '${location}' as is.`);
+        return;
+      }
+    } catch {
+      log(`Cuttings::plantCutting: could not compare with existing file at '${location}'.`);
+    }
     log(`Cuttings::plantCutting: overwriting existing file at '${location}'.`);
   }
 

--- a/packages/cuttings/src/hydrate.ts
+++ b/packages/cuttings/src/hydrate.ts
@@ -1,0 +1,50 @@
+import type { ClientInterface } from '@figmarine/rest';
+import { log } from '@figmarine/logger';
+
+import type { Cutting } from './schemas/cutting';
+import { printCutting } from './logHelpers';
+import { take } from './take';
+
+/**
+ * Options for {@link hydrate}.
+ */
+export type HydrateOptions = {
+  /**
+   * The `@figmarine/rest` client used to call the Figma REST API.
+   */
+  client: ClientInterface;
+
+  /**
+   * The Cutting to re-hydrate.
+   */
+  cutting: Cutting;
+};
+
+/**
+ * Re-hydrates a Cutting: fetches fresh data for every facet the Cutting
+ * records, and returns a new Cutting with up-to-date data and hydration
+ * timestamps. Storage metadata (label, last stored time and file path)
+ * carries over so the refreshed Cutting can be planted back where the
+ * original grew.
+ *
+ * @param options See {@link HydrateOptions}.
+ * @returns A freshly hydrated copy of the Cutting.
+ */
+export async function hydrate({ client, cutting }: HydrateOptions): Promise<Cutting> {
+  log(`Cuttings::hydrate: re-hydrating cutting ${printCutting(cutting)}.`);
+
+  const fresh = await take({
+    client,
+    facets: cutting.facets,
+    label: cutting.meta.label,
+  });
+
+  return {
+    ...fresh,
+    meta: {
+      ...fresh.meta,
+      lastStored: cutting.meta.lastStored,
+      lastKnownFilePath: cutting.meta.lastKnownFilePath,
+    },
+  };
+}

--- a/packages/cuttings/src/index.ts
+++ b/packages/cuttings/src/index.ts
@@ -1,4 +1,7 @@
 export * from './schemas/cutting';
 export * from './schemas/facet';
+export * from './figmaUrl';
 export * from './fs';
+export * from './hydrate';
+export * from './slim';
 export * from './take';

--- a/packages/cuttings/src/index.ts
+++ b/packages/cuttings/src/index.ts
@@ -3,5 +3,6 @@ export * from './schemas/facet';
 export * from './figmaUrl';
 export * from './fs';
 export * from './hydrate';
+export * from './logHelpers';
 export * from './slim';
 export * from './take';

--- a/packages/cuttings/src/logHelpers.ts
+++ b/packages/cuttings/src/logHelpers.ts
@@ -37,6 +37,10 @@ export function printFacets(cutting: Cutting): string {
  * @returns A multi-line string with the error messages.
  */
 export function printZodError(error: ZodError<unknown>): string {
-  // TODO: implement.
-  return JSON.stringify(error);
+  return error.issues
+    .map((issue) => {
+      const where = issue.path.length ? issue.path.map(String).join('.') : '<root>';
+      return `  - ${where}: ${issue.message}`;
+    })
+    .join('\n');
 }

--- a/packages/cuttings/src/schemas/cutting.ts
+++ b/packages/cuttings/src/schemas/cutting.ts
@@ -104,7 +104,8 @@ export type Cutting = {
  * @returns Whether it is a valid Cutting.
  */
 export function isCutting(blob: unknown): blob is Cutting {
-  log(`Cutting::isCutting: Checking out the following blob: ${JSON.stringify(blob)}`);
+  // Do not stringify the blob: real cuttings weigh megabytes.
+  log(`Cutting::isCutting: Checking a candidate blob.`);
   const outcome = CuttingSchema.safeParse(blob);
 
   if (outcome.success) {

--- a/packages/cuttings/src/schemas/cutting.ts
+++ b/packages/cuttings/src/schemas/cutting.ts
@@ -66,10 +66,10 @@ export const CuttingSchema = z.object({
  * a `data` object, with components, component sets, files, projects,
  * styles and variables, which are filled by the Cutting when it calls
  * facet endpoints. Each of these data objects is a dictionary where
- * keys are ids (e.g. `fileKey` for `data.files`) and values are the
- * item being represented. All types come from Figma except for File
- * types, which are simplified from `GetFile` response bodies to exclude
- * irrelevant data.
+ * keys are ids (e.g. `fileKey` for `data.files`, published `key` for
+ * `data.components`) and values are the item being represented. All
+ * types come from Figma except for File types, which are simplified
+ * from `GetFile` response bodies to exclude irrelevant data.
  */
 export type Cutting = {
   /**
@@ -80,7 +80,7 @@ export type Cutting = {
   /**
    * The Cutting's array of facets.
    */
-  facets: z.infer<typeof CuttingSchema.shape.facets>;
+  facets: z.input<typeof CuttingSchema.shape.facets>;
 
   /**
    * The Cutting's stored data.

--- a/packages/cuttings/src/schemas/cutting.ts
+++ b/packages/cuttings/src/schemas/cutting.ts
@@ -1,5 +1,4 @@
 import type {
-  File,
   LocalVariable,
   LocalVariableCollection,
   Project,
@@ -14,6 +13,7 @@ import { z } from 'zod';
 
 import { printCutting, printZodError } from '../logHelpers';
 import { FacetSchema } from './facet';
+import type { SlimFile } from '../slim';
 
 export const CuttingSchema = z.object({
   meta: z.object({
@@ -47,15 +47,15 @@ export const CuttingSchema = z.object({
    * Data stored in the Cutting.
    */
   data: z.object({
-    components: z.record(z.string(), z.object({}).passthrough()),
-    componentSets: z.record(z.string(), z.object({}).passthrough()),
-    files: z.record(z.string(), z.object({}).passthrough()),
-    localVariables: z.record(z.string(), z.object({}).passthrough()),
-    localVariableCollections: z.record(z.string(), z.object({}).passthrough()),
-    projects: z.record(z.string(), z.object({}).passthrough()),
-    publishedVariables: z.record(z.string(), z.object({}).passthrough()),
-    publishedVariableCollections: z.record(z.string(), z.object({}).passthrough()),
-    styles: z.record(z.string(), z.object({}).passthrough()),
+    components: z.record(z.string(), z.looseObject({})),
+    componentSets: z.record(z.string(), z.looseObject({})),
+    files: z.record(z.string(), z.looseObject({})),
+    localVariables: z.record(z.string(), z.looseObject({})),
+    localVariableCollections: z.record(z.string(), z.looseObject({})),
+    projects: z.record(z.string(), z.looseObject({})),
+    publishedVariables: z.record(z.string(), z.looseObject({})),
+    publishedVariableCollections: z.record(z.string(), z.looseObject({})),
+    styles: z.record(z.string(), z.looseObject({})),
   }),
 });
 
@@ -88,7 +88,7 @@ export type Cutting = {
   data: {
     components: Record<string, PublishedComponent>;
     componentSets: Record<string, PublishedComponentSet>;
-    files: Record<string, File>;
+    files: Record<string, SlimFile>;
     localVariables: Record<string, LocalVariable>;
     localVariableCollections: Record<string, LocalVariableCollection>;
     projects: Record<string, Project>;

--- a/packages/cuttings/src/schemas/facet.ts
+++ b/packages/cuttings/src/schemas/facet.ts
@@ -31,16 +31,41 @@ const BASIC_ENDPOINT_TYPES = [
 ] as const;
 const VERSIONED_ENDPOINT_TYPES = ['GetFile'] as const;
 
-const ALL_ENDPOINT_TYPES = [...BASIC_ENDPOINT_TYPES, ...VERSIONED_ENDPOINT_TYPES] as const;
+/**
+ * Every endpoint type that facets can declare, whether `take` implements
+ * it yet or not.
+ */
+export const ALL_ENDPOINT_TYPES = [...BASIC_ENDPOINT_TYPES, ...VERSIONED_ENDPOINT_TYPES] as const;
+
+/**
+ * Endpoints that `take` can currently fetch. Other endpoint types are
+ * accepted by the schemas so that cutting files remain forward-compatible,
+ * but `take` throws on them.
+ */
+export const IMPLEMENTED_ENDPOINT_TYPES = [
+  'GetFile',
+  'GetFileComponents',
+  'GetFileComponentSets',
+  'GetFileStyles',
+] as const satisfies readonly (typeof ALL_ENDPOINT_TYPES)[number][];
+
+/**
+ * The last time a facet's data was fetched through the Figma REST API,
+ * as a Unix epoch in milliseconds. Zero when never fetched, e.g. in a
+ * hand-written cutting config that was not taken yet.
+ */
+const lastHydrated = z.number().gte(0).default(0);
 
 const VersionedEndpointSchema = z.object({
   id: z.string(),
   endpoint: z.enum(VERSIONED_ENDPOINT_TYPES),
   version: z.string().optional(),
+  lastHydrated,
 });
 const BasicEndpointSchema = z.object({
   id: z.string(),
   endpoint: z.enum(BASIC_ENDPOINT_TYPES),
+  lastHydrated,
 });
 
 export const FacetSchema = z.discriminatedUnion('endpoint', [
@@ -49,51 +74,26 @@ export const FacetSchema = z.discriminatedUnion('endpoint', [
 ]);
 
 /**
- * Metadata for a Cutting facet. Includes the identifying information passed by
- * the user and the metadata maintained by the library. Should be sufficient to
- * know what data a facet fetches, with what API, and how old it is.
+ * A facet describes a source of data stored in a Cutting. It is identified
+ * by a REST API endpoint and the id passed to that endpoint, alongside
+ * additional parameters for some facet types:
+ * - File:         `fileKey`
+ * - Style:        `key`
+ * - Component:    `key`
+ * - ComponentSet: `key`
+ * - Project:      `projectId`
+ * - Team:         `teamId`
+ *
+ * Facets maintained by the library also carry a `lastHydrated` timestamp;
+ * hand-written facets may omit it.
  */
-export type Facet = z.infer<typeof FacetSchema>;
-
-export const FacetMetaSchema = z.object({
-  /**
-   * Type of data referred to here.
-   */
-  endpoint: z.enum(ALL_ENDPOINT_TYPES),
-
-  /**
-   * Identifier for this data. Interpreted based on the data type being referred to:
-   * - File:         `fileKey`
-   * - Style:        `key`
-   * - Component:    `key`
-   * - ComponentSet: `key`
-   * - Project:      `projectId`
-   * - Team:         `teamId`
-   */
-  id: z.string(),
-
-  /**
-   * Secondary identifying information for some API endpoints / cutting types.
-   */
-  version: z.string().optional(),
-
-  /**
-   * Major version number of the Figma REST API used to fill data into a Cutting.
-   */
-  apiVersion: z.number().gte(1).lte(2),
-
-  /**
-   * The last time this data was fetched through the Figma REST API. Defaults to zero when never fetched.
-   */
-  lastHydrated: z.number(),
-});
+export type Facet = z.input<typeof FacetSchema>;
 
 /**
- * A facet describes a source of data stored in the Cutting. It's
- * identified by a REST API endpoint and id param passed to the
- * endpoint, alongside additional parameters for some facet types.
+ * A facet as stored inside a Cutting that went through `take`, i.e. with
+ * its hydration timestamp filled in.
  */
-export type FacetMeta = z.infer<typeof FacetMetaSchema>;
+export type HydratedFacet = z.output<typeof FacetSchema>;
 
 /**
  * Checks if a data blob is a valid facet.

--- a/packages/cuttings/src/schemas/facet.ts
+++ b/packages/cuttings/src/schemas/facet.ts
@@ -101,7 +101,7 @@ export type HydratedFacet = z.output<typeof FacetSchema>;
  * @returns Whether it is a valid facet.
  */
 export function isFacet(blob: unknown): blob is Facet {
-  log(`Facet::isFacet: Checking out the following blob: ${JSON.stringify(blob)}`);
+  log(`Facet::isFacet: Checking a candidate blob.`);
   const outcome = FacetSchema.safeParse(blob);
 
   if (outcome.success) {

--- a/packages/cuttings/src/slim.ts
+++ b/packages/cuttings/src/slim.ts
@@ -1,0 +1,48 @@
+import type { File, V1 } from '@figmarine/rest';
+
+/**
+ * The fields of a `GetFile` response body kept in a Cutting. Everything
+ * else (thumbnails, access role, link settings…) is volatile or
+ * irrelevant to offline analysis and would create meaningless diffs when
+ * cuttings are committed to a repository.
+ *
+ * Must stay in sync with the `File` type of `@figmarine/rest`; the
+ * `satisfies` clause and the assertion below make drift a compile error.
+ */
+const FILE_FIELDS = [
+  'name',
+  'lastModified',
+  'editorType',
+  'version',
+  'document',
+  'components',
+  'componentSets',
+  'schemaVersion',
+  'styles',
+  'mainFileKey',
+  'branches',
+] as const satisfies readonly (keyof File)[];
+
+type MissingFileField = Exclude<keyof File, (typeof FILE_FIELDS)[number]>;
+// Compile-time completeness check: fails when File gains a field that
+// FILE_FIELDS does not list.
+true satisfies MissingFileField extends never ? true : false;
+
+/**
+ * Slims a `GetFile` response body down to the fields worth storing in a
+ * Cutting.
+ * @param body The raw `GetFile` response body.
+ * @returns The slimmed file.
+ */
+export function slimFile(body: V1.GetFile.ResponseBody): File {
+  const file: Partial<File> = {};
+
+  for (const field of FILE_FIELDS) {
+    if (field in body) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      file[field] = body[field] as any;
+    }
+  }
+
+  return file as File;
+}

--- a/packages/cuttings/src/slim.ts
+++ b/packages/cuttings/src/slim.ts
@@ -1,6 +1,18 @@
 import type { File, V1 } from '@figmarine/rest';
 
 /**
+ * A branch entry as stored in a Cutting: the volatile signed
+ * `thumbnail_url` is dropped so refreshes stay diff-stable.
+ */
+export type SlimBranch = Omit<NonNullable<File['branches']>[number], 'thumbnail_url'>;
+
+/**
+ * A Figma file as stored in a Cutting: the fields of `File`, with branch
+ * entries slimmed of their volatile thumbnail URLs.
+ */
+export type SlimFile = Omit<File, 'branches'> & { branches?: SlimBranch[] };
+
+/**
  * The fields of a `GetFile` response body kept in a Cutting. Everything
  * else (thumbnails, access role, link settings…) is volatile or
  * irrelevant to offline analysis and would create meaningless diffs when
@@ -34,8 +46,8 @@ true satisfies MissingFileField extends never ? true : false;
  * @param body The raw `GetFile` response body.
  * @returns The slimmed file.
  */
-export function slimFile(body: V1.GetFile.ResponseBody): File {
-  const file: Partial<File> = {};
+export function slimFile(body: V1.GetFile.ResponseBody): SlimFile {
+  const file: Partial<SlimFile> = {};
 
   for (const field of FILE_FIELDS) {
     if (field in body) {
@@ -44,5 +56,9 @@ export function slimFile(body: V1.GetFile.ResponseBody): File {
     }
   }
 
-  return file as File;
+  if (body.branches) {
+    file.branches = body.branches.map(({ thumbnail_url: _thumbnailUrl, ...branch }) => branch);
+  }
+
+  return file as SlimFile;
 }

--- a/packages/cuttings/src/take.ts
+++ b/packages/cuttings/src/take.ts
@@ -5,13 +5,14 @@ import { log } from '@figmarine/logger';
 import type { Cutting } from './schemas/cutting';
 import { Facet } from './schemas/facet';
 import { printFacet } from './logHelpers';
+import { slimFile } from './slim';
 
 /**
  * Creates an empty Cutting.
  * @param {string} opts.label An optional but highly recommended label describing the Cutting.
  * @returns An empty Cutting.
  */
-function initCutting({ facets, label }: { facets?: Facet[]; label?: string } = {}): Cutting {
+function initCutting({ label }: { label?: string } = {}): Cutting {
   return {
     meta: {
       figmarineVersion: 0,
@@ -19,7 +20,7 @@ function initCutting({ facets, label }: { facets?: Facet[]; label?: string } = {
       lastStored: 0,
       lastKnownFilePath: undefined,
     },
-    facets: facets ?? [],
+    facets: [],
     data: {
       components: {},
       componentSets: {},
@@ -35,54 +36,116 @@ function initCutting({ facets, label }: { facets?: Facet[]; label?: string } = {
 }
 
 /**
- * TODO doc
+ * Throws when a facet's network call did not succeed. The REST client
+ * already rejects on most non-2xx responses; this guards against clients
+ * configured otherwise.
+ * @param response The Axios response received for the facet.
+ * @param facet The facet being loaded.
  */
-function handleTakeResponse<T = unknown>(response: AxiosResponse<T>): void {
+function assertResponseOk<T>(response: AxiosResponse<T>, facet: Facet): void {
   if (response.status !== 200) {
     throw new Error(
-      `Cuttings::take: network call failed. ${response.status}: ${response.statusText}.`,
+      `Cuttings::take: network call failed for facet ${printFacet(facet)}. ${response.status}: ${response.statusText}.`,
     );
   }
 }
 
 /**
- * TODO doc
+ * Fetches one facet's data and merges it into a Cutting's data record.
+ * @param client The REST API client to fetch with.
+ * @param facet The facet to load.
+ * @param cutting The cutting to fill.
  */
-export type TakeOptions = {
-  client: ClientInterface;
-  facets: Facet[];
-  label: string;
-};
-
-/**
- * TODO doc
- * @param param0
- * @returns
- */
-export async function take({ client, facets, label }: TakeOptions): Promise<Cutting> {
-  log(`Cuttings:take:: starting analysis of facets.`);
-
-  const cutting = initCutting({ facets, label });
-
-  for (const facet of facets) {
-    log(`Cuttings:take:: loading facet: ${printFacet(facet)}`);
-
-    if (facet.endpoint === 'GetFile') {
-      log(`Cuttings:take::   loading file ${facet.id}`);
+async function loadFacet(client: ClientInterface, facet: Facet, cutting: Cutting): Promise<void> {
+  switch (facet.endpoint) {
+    case 'GetFile': {
       const response = await client.v1.getFile(facet.id, {
         // depth, ids, geometry, plugin_data are not yet supported until we introduce facet options.
         branch_data: true,
         version: facet.version,
       });
-
-      handleTakeResponse(response);
-      log(`Cuttings::take: successfully loaded file '${facet.id}'.`);
-      // TODO: remove unnecessary content
-      cutting.data.files.id = response.data;
-    } else {
-      throw new Error(`Cuttings:take:: endpoint type ${facet.endpoint} is not implemented yet.`);
+      assertResponseOk(response, facet);
+      cutting.data.files[facet.id] = slimFile(response.data);
+      break;
     }
+
+    case 'GetFileComponents': {
+      const response = await client.v1.getFileComponents(facet.id);
+      assertResponseOk(response, facet);
+      for (const component of response.data.meta.components) {
+        cutting.data.components[component.key] = component;
+      }
+      break;
+    }
+
+    case 'GetFileComponentSets': {
+      const response = await client.v1.getFileComponentSets(facet.id);
+      assertResponseOk(response, facet);
+      for (const componentSet of response.data.meta.component_sets) {
+        cutting.data.componentSets[componentSet.key] = componentSet;
+      }
+      break;
+    }
+
+    case 'GetFileStyles': {
+      const response = await client.v1.getFileStyles(facet.id);
+      assertResponseOk(response, facet);
+      for (const style of response.data.meta.styles) {
+        cutting.data.styles[style.key] = style;
+      }
+      break;
+    }
+
+    default:
+      throw new Error(`Cuttings::take: endpoint type ${facet.endpoint} is not implemented yet.`);
   }
+}
+
+/**
+ * Options for {@link take}.
+ */
+export type TakeOptions = {
+  /**
+   * The `@figmarine/rest` client used to call the Figma REST API.
+   */
+  client: ClientInterface;
+
+  /**
+   * The facets to fetch into the new Cutting.
+   */
+  facets: Facet[];
+
+  /**
+   * An optional but highly recommended label describing the Cutting.
+   */
+  label?: string;
+};
+
+/**
+ * Takes a new Cutting: fetches every facet through the Figma REST API and
+ * stores the results in a fresh Cutting.
+ *
+ * Facets are fetched sequentially on purpose: the REST client applies rate
+ * limiting per request, and bursts of parallel file downloads are the main
+ * way to hit Figma's rate limits.
+ *
+ * @param options See {@link TakeOptions}.
+ * @returns The new Cutting.
+ */
+export async function take({ client, facets, label }: TakeOptions): Promise<Cutting> {
+  log(`Cuttings::take: starting analysis of ${facets.length} facets.`);
+
+  const cutting = initCutting({ label });
+
+  for (const facet of facets) {
+    log(`Cuttings::take: loading facet ${printFacet(facet)}.`);
+    await loadFacet(client, facet, cutting);
+    log(`Cuttings::take: successfully loaded facet ${printFacet(facet)}.`);
+
+    cutting.facets.push({ ...facet, lastHydrated: Date.now() });
+  }
+
+  log(`Cuttings::take: done, loaded ${cutting.facets.length} facets.`);
 
   return cutting;
 }


### PR DESCRIPTION
# Cuttings: complete the package

Third PR of the `fable` plan. **Stacked on #132** — merge that first and this diff reduces to the cuttings work.

## What a cutting now is

A JSON snapshot of Figma content with three parts: `meta` (label, format version, storage info), `facets` (the API calls needed to re-hydrate, with per-facet `lastHydrated` timestamps), and `data` (files keyed by file key; published components/component sets/styles keyed by their published key). Documented in the package README, including the file format.

## What was built (per the agreed design: file-scoped endpoints, slim File storage)

- **`take()`** — fetches the file-scoped facet set (`GetFile`, `GetFileComponents`, `GetFileComponentSets`, `GetFileStyles`), fixes the original `data.files.id` keying bug, slims file bodies, stamps hydration times. Unimplemented endpoint types throw clearly.
- **`hydrate()`** — refreshes a cutting from its recorded facets, preserving storage metadata so it can be replanted in place.
- **`parseFigmaUrl()`** — `/design/`, legacy `/file/`, `/board/`, `/slides/`, `/proto/`, `/deck/` and branch URLs → API file keys; node ids normalized to API format including instance paths (`I2005-6797;2005-6798` → `I2005:6797;2005:6798`).
- **`slimFile()`** — keeps the fields analysis needs (full document tree included), drops volatile ones (thumbnails, role, link access, branch thumbnail signatures), with a compile-time completeness check against the rest package's `File` type.
- **Diff-stability as a contract**: `plantCutting` now skips the write when only timestamps would change. A scheduled refresh against unchanged Figma files produces **zero diff** (previously 26 lines of timestamp churn per refresh — which would have meant a noise PR per cron run in consumer repos).
- `printZodError` implemented and exported; `isCutting`/`isFacet` no longer stringify megabyte blobs into logs; cuttings pretty-print to disk for reviewable diffs; deprecated zod `.passthrough()` migrated; phantom `build:debug` scripts removed.

## TDD with real data

`pnpm fixtures:regen` records real API responses for the three designated test files. Real data immediately caught real bugs:

- Full document trees weigh **48MB–401MB** — fixtures are recorded depth-limited (4/3/2) at 1.7MB total, with the caveat documented; they're marked `linguist-generated` so they collapse in PR views.
- The blob-stringifying log calls would have serialized 48MB per validation.
- **None of the three files publish library components/styles** — the recorded published-endpoint responses are genuinely empty (now a test of its own), so the keyed-storage paths are exercised by spec-typed fixtures built from the debug file's real component metadata (`satisfies PublishedComponent[]` keeps them honest).
- Signed AWS thumbnail URLs made every fixture regen churn — the recorder now normalizes volatile fields and **regen is byte-idempotent** (verified with two consecutive runs).

**73 tests, 100% statement and function coverage** on the package. `pnpm build/typecheck/lint/test` all green monorepo-wide.

## Review notes

Thermonuclear review ran twice (initial 6-angle pass during development + a 2-agent verification pass on the final diff with empirical reproduction). All CONFIRMED findings fixed, including four found only by executing the built package against the recorded fixtures (node-id half-normalization, branch thumbnail churn, no-op refresh diff instability, URIError leaking through `parseFigmaUrl`). Known limitations, documented: team/project/variables facets are schema-reserved but unimplemented (variables need Enterprise); depth-truncated fixture documents can reference nodes beyond the recorded depth (test artifact only — real takes are full-depth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uuNuww7pz54s1eV4dv2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6uuNuww7pz54s1eV4dv2e)_