### PR TITLE
feat: Enable releases for cuttings and nursery

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@
     </td>
     <td>
       <h3><a href="./packages/cuttings/">Cuttings</a></h3>
-      <div><code role="status" aria-label="Work in progress">WIP</code> A library that creates JSON representations of Figma content (files, styles, etc.).</div>
+      <div>A library that creates JSON representations of Figma content (files, styles, etc.).</div>
     </td>
     <td>
-      <h3><a href="./apps/nursery/">Nursery</a></h3>
-      <div><code role="status" aria-label="To do">TODO</code> A library for fetching, storing and rehydrating cuttings automatically.</div>
+      <h3><a href="./packages/nursery/">Nursery</a></h3>
+      <div>A CLI for fetching, storing and rehydrating cuttings automatically.</div>
     </td>
     <td>
       <h3><a href="./packages/eslint-plugin-figma/">ESLint Plugin</a></h3>

--- a/TODO.md
+++ b/TODO.md
@@ -44,18 +44,20 @@
 - [ ] Implement the server needed
 - [ ] And the auth ui?
 
-## apps/nursery
+## packages/nursery
 
-- [ ] Build nursery app
-- [ ] Create and document the `figorder.json` file format
-- [ ] Use the cuttings package to support passing orders
-- [ ] Ensure all retrieved cuttings are long-term stored by default
-- [ ] Include versioning in cache keys / file keys in the nursery storage
-- [ ] Handle cutting rehydration
-- [ ] Add unit tests
-- [ ] Write a README
-- [ ] Write CD code to release the package
-- [ ] Add repository and homepage to manifest
+- [x] Build nursery CLI
+- [x] Create and document the config file format (`.figmarine/nursery.json`)
+- [x] Use the cuttings package to take and refresh cuttings
+- [x] Ensure all retrieved cuttings are long-term stored by default
+- [x] Support pinning file versions in the config
+- [x] Handle cutting rehydration
+- [x] Add unit tests
+- [x] Write a README
+- [x] Write CD code to release the package
+- [x] Add repository and homepage to manifest
+- [ ] CircleCI workflow template
+- [ ] Claude Code skill wrapping the CLI
 
 ## apps/lint
 

--- a/docs/RELEASE_AUTOMATION.md
+++ b/docs/RELEASE_AUTOMATION.md
@@ -103,9 +103,11 @@ be enabled:
   configured with a 2-day `cooldown` so its PRs propose versions that clear
   the gate. If you ever need a fresher version, add it to
   `minimumReleaseAgeExclude`.
-- **Packages that release**: `multi-release.config.js` ignores `config-*`,
-  `cuttings`, `nursery` and `eslint-plugin-figma` for now. Remove entries
-  from `ignorePackages` to start releasing them.
+- **Packages that release**: `@figmarine/cache`, `@figmarine/logger`,
+  `@figmarine/rest`, `@figmarine/cuttings` and `@figmarine/nursery`.
+  `multi-release.config.js` ignores `config-*` (never published) and
+  `eslint-plugin-figma` (not ready for release yet); remove entries from
+  `ignorePackages` to start releasing them.
 - **GitLab mirror.** The README badge points to a GitLab CI mirror whose
   pipeline definition lives outside this repository. After the pnpm 11 /
   Node ≥ 22.22 upgrade, that pipeline must install pnpm 11 (e.g. via

--- a/multi-release.config.js
+++ b/multi-release.config.js
@@ -3,8 +3,6 @@ export default {
     // Never included.
     'packages/config-*',
     // Not ready for release yet.
-    'packages/cuttings',
-    'packages/nursery',
     'packages/eslint-plugin-figma',
   ],
   deps: {

--- a/packages/cuttings/README.md
+++ b/packages/cuttings/README.md
@@ -133,7 +133,7 @@ to the fixture files).
 - [x] Document the cutting file format
 - [ ] Support team, project and variable facets
 - [ ] Facet options (depth, geometry, plugin_data)
-- [ ] Automate NPM releases
+- [x] Automate NPM releases
 
 
 ## :wave: Contributing

--- a/packages/nursery/README.md
+++ b/packages/nursery/README.md
@@ -126,7 +126,7 @@ when Figma content changed. Copy it to
 - [x] GitHub Actions workflow template for scheduled refreshes
 - [ ] CircleCI workflow template
 - [ ] Claude Code skill wrapping the CLI
-- [ ] Automate NPM releases
+- [x] Automate NPM releases
 
 ## :wave: Contributing
 


### PR DESCRIPTION
# Distribution: turn on CD for the new packages

Final PR of the `fable` plan. **Stacked on #134** (→ #133 → #132) — merge those first and this reduces to a small config + docs diff.

## ⚠️ One manual step before merging to `main`

You chose **0.x first releases** for the new packages. semantic-release otherwise debuts packages at 1.0.0, so seed these tags (my session's git proxy can't push tags):

```sh
git fetch origin main
git tag '@figmarine/cuttings@0.0.1' origin/main
git tag '@figmarine/nursery@0.0.1' origin/main
git push origin '@figmarine/cuttings@0.0.1' '@figmarine/nursery@0.0.1'
```

With the tags in place, the first automated releases will be `0.1.0` (feat → minor). Note semantic-release's semantics: a commit with a `BREAKING CHANGE` footer will still jump to `1.0.0` — the 0.x runway holds only for feat/fix work, so declare 1.0 by shipping a deliberate breaking commit when ready.

## What changes

- **`multi-release.config.js`**: `packages/cuttings` and `packages/nursery` leave `ignorePackages`. On the next merge to `main` with their `feat` commits, multi-semantic-release publishes `@figmarine/cuttings` and `@figmarine/nursery` to npm alongside cache/logger/rest, with `deps.bump: inherit` keeping cross-package ranges aligned and semantic-release-pnpm rewriting the `workspace:*` protocols at publish time. Verified twice: `pnpm release:dry` loads and queues 5 packages, and an isolated dry run simulating `main` released all 5 in correct topological order (rest → cuttings → nursery) with workspace deps resolved to concrete versions.
- Root **README** project table updated (cuttings/nursery no longer WIP/TODO; nursery link fixed to `packages/`), **TODO.md** nursery section reconciled with reality, **docs/RELEASE_AUTOMATION.md** package list updated, package roadmaps ticked.

## How close to CD are we now?

With #132's chain fixes, the end-to-end automation is: Figma spec release → Dependabot (2-day cooldown) → regen + auto-merge → semantic-release publish — no human in the loop for spec updates, and daily fallback releases for `GITHUB_TOKEN`-attributed merges. Cuttings/nursery releases ride the same pipeline off conventional commits. Consumer-side CD: the nursery ships a GitHub Actions template that refreshes committed cuttings on a schedule and opens PRs only when Figma content actually changed (diff-stability verified byte-for-byte in #133/#134).

Left out deliberately (tracked in the nursery README roadmap): `eslint-plugin-figma` stays unreleased (still a stub), CircleCI template and the Claude Code skill await your call on priorities.

## Review notes

Reviewed with an adversarial verification agent that packed both tarballs (bin, schema and templates ship correctly), confirmed the npm names are unclaimed and the workspace-protocol rewriting works (checked against the published `@figmarine/rest` on npm), and ran the isolated release simulation above. Its two findings — the 1.0.0-vs-0.x decision (escalated to you, resolved as 0.x) and a docs wording fix — are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uuNuww7pz54s1eV4dv2e