### PR TITLE
feat: serve compatible REST API calls from cuttings, transparently

### DIFF
--- a/packages/cuttings/README.md
+++ b/packages/cuttings/README.md
@@ -83,6 +83,48 @@ const fresh = await hydrate({ client, cutting: stored });
 plantCutting(fresh, stored.meta.lastKnownFilePath!);
 ```
 
+### Serving API calls from cuttings
+
+Attach cuttings to a `@figmarine/rest` client and compatible API calls are
+answered from planted data instead of the network — the calling code does
+not change at all:
+
+```ts
+import { Client } from '@figmarine/rest';
+import { attachCuttings, digCutting } from '@figmarine/cuttings';
+
+const client = await Client({ personalAccessToken: process.env.FIGMA_PERSONAL_ACCESS_TOKEN });
+const cutting = digCutting('.figmarine/cuttings/design-system.cutting.figmarine.json');
+
+const detach = attachCuttings(client, [cutting]);
+
+// Served from the cutting: no network, no rate limit budget.
+const file = await client.v1.getFile(fileKey);
+
+// Not snapshotted by cuttings: falls through to the network.
+const versions = await client.v1.getFileVersions(fileKey);
+
+detach();
+```
+
+A call is served when it is a `GET` request to a snapshotted endpoint
+(`GetFile`, `GetFileComponents`, `GetFileComponentSets`, `GetFileStyles`),
+for a file key an attached cutting holds, with query parameters the stored
+data can honour. `GetFile` calls with `ids`, `depth`, `geometry` or
+`plugin_data` always fall through, and `version` must match the facet's pin
+or the stored file's version. Everything else behaves as usual, so a client
+with cuttings attached keeps working for uncovered endpoints.
+
+Served responses differ from the wire format in one documented way: file
+bodies are the stored `SlimFile` (no `thumbnailUrl`, `role` or
+`linkAccess`). They carry an `x-figmarine-cutting` response header (exported
+as `CUTTING_SOURCE_HEADER`) so tooling can tell data sources apart. Cuttings
+are authoritative regardless of age — freshness is a separate concern,
+handled with `hydrate` or `@figmarine/nursery` refresh schedules.
+
+If you configure your cuttings with `@figmarine/nursery`, prefer its
+`connectNursery(client)` helper, which digs every planted cutting for you.
+
 ### The cutting file format
 
 A cutting file is a JSON document with three top-level keys:
@@ -133,6 +175,7 @@ to the fixture files).
 - [x] Document the cutting file format
 - [ ] Support team, project and variable facets
 - [ ] Facet options (depth, geometry, plugin_data)
+- [x] Serve compatible REST client calls from cuttings
 - [x] Automate NPM releases
 
 

--- a/packages/cuttings/README.md
+++ b/packages/cuttings/README.md
@@ -115,12 +115,17 @@ data can honour. `GetFile` calls with `ids`, `depth`, `geometry` or
 or the stored file's version. Everything else behaves as usual, so a client
 with cuttings attached keeps working for uncovered endpoints.
 
-Served responses differ from the wire format in one documented way: file
-bodies are the stored `SlimFile` (no `thumbnailUrl`, `role` or
-`linkAccess`). They carry an `x-figmarine-cutting` response header (exported
-as `CUTTING_SOURCE_HEADER`) so tooling can tell data sources apart. Cuttings
-are authoritative regardless of age — freshness is a separate concern,
-handled with `hydrate` or `@figmarine/nursery` refresh schedules.
+Served responses differ from the wire format in documented ways: file
+bodies are the stored `SlimFile` — no `thumbnailUrl`, `role` or
+`linkAccess`, `branches` (when the file has any) always present but without
+per-branch thumbnails. The TypeScript response types cannot express these
+deletions, so code that branches on such fields must tolerate `undefined`
+on served responses. Responses carry an `x-figmarine-cutting` response
+header (exported as `CUTTING_SOURCE_HEADER`) so tooling can tell data
+sources apart, and bypass the client's development cache in both
+directions. Cuttings are authoritative regardless of age — freshness is a
+separate concern, handled with `hydrate` or `@figmarine/nursery` refresh
+schedules.
 
 If you configure your cuttings with `@figmarine/nursery`, prefer its
 `connectNursery(client)` helper, which digs every planted cutting for you.

--- a/packages/cuttings/src/__fixtures__/mockedClient.ts
+++ b/packages/cuttings/src/__fixtures__/mockedClient.ts
@@ -1,0 +1,37 @@
+import type { ClientInterface } from '@figmarine/rest';
+import { vi } from 'vitest';
+
+import { API_FIXTURE_FILES, loadApiFixture } from './api';
+
+/**
+ * Wraps recorded response data in the shape of an Axios success response.
+ * @param data The response body.
+ * @returns An object that quacks like an `AxiosResponse`.
+ */
+export function mockResponse<T>(data: T) {
+  return { status: 200, statusText: 'OK', data };
+}
+
+/**
+ * Builds a `@figmarine/rest` client mocked with the recorded API fixtures
+ * of one of the fixture files, for tests that exercise cutting-taking
+ * without a network.
+ * @param label The fixture file whose recorded responses to serve.
+ * @returns A mocked client.
+ */
+export function makeMockedClient(
+  label: keyof typeof API_FIXTURE_FILES = 'figma-api-debug-file',
+): ClientInterface {
+  return {
+    v1: {
+      getFile: vi.fn(async () => mockResponse(loadApiFixture(label, 'GetFile'))),
+      getFileComponents: vi.fn(async () =>
+        mockResponse(loadApiFixture(label, 'GetFileComponents')),
+      ),
+      getFileComponentSets: vi.fn(async () =>
+        mockResponse(loadApiFixture(label, 'GetFileComponentSets')),
+      ),
+      getFileStyles: vi.fn(async () => mockResponse(loadApiFixture(label, 'GetFileStyles'))),
+    },
+  } as unknown as ClientInterface;
+}

--- a/packages/cuttings/src/__tests__/attach.spec.ts
+++ b/packages/cuttings/src/__tests__/attach.spec.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import { test as base, type Mock } from 'vitest';
 import { Client, type ClientInterface, type V1 } from '@figmarine/rest';
 import type { AxiosAdapter } from 'axios';
@@ -197,6 +201,61 @@ describe('@figmarine/cuttings - attach', () => {
       expect(networkAdapter).toHaveBeenCalledTimes(4);
     });
 
+    it('honours constraints embedded in the URL query string', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      // Constraints in the raw URL constrain the response just as much as
+      // `params` do: version/depth mismatches must fall through.
+      await client.instance.get(`/v1/files/${FILE_KEY}?version=someOtherVersion`);
+      await client.instance.get(`/v1/files/${FILE_KEY}?ids=1:2&depth=1`);
+      expect(networkAdapter).toHaveBeenCalledTimes(2);
+
+      // While compatible URL-embedded constraints still get served.
+      const served = await client.instance.get(`/v1/files/${FILE_KEY}?branch_data=true`);
+      expect(served.headers[CUTTING_SOURCE_HEADER]).toBeDefined();
+      expect(networkAdapter).toHaveBeenCalledTimes(2);
+    });
+
+    it('honours constraints passed as URLSearchParams', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      await client.instance.get(`/v1/files/${FILE_KEY}`, {
+        params: new URLSearchParams({ version: 'someOtherVersion' }),
+      });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+
+      const served = await client.instance.get(`/v1/files/${FILE_KEY}`, {
+        params: new URLSearchParams({ branch_data: 'true' }),
+      });
+      expect(served.headers[CUTTING_SOURCE_HEADER]).toBeDefined();
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('goes to the network when params cannot be introspected', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      class ExoticParams {
+        toString() {
+          return 'version=someOtherVersion';
+        }
+      }
+      await client.instance.get(`/v1/files/${FILE_KEY}`, { params: new ExoticParams() });
+
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
     it('goes to the network for files the cutting does not hold', async ({
       client,
       cutting,
@@ -208,6 +267,40 @@ describe('@figmarine/cuttings - attach', () => {
 
       expect(response.data).toStrictEqual({ reached: 'network' });
       expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('goes to the network when the stored file lost its core fields', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      const hollow = structuredClone(cutting);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      hollow.data.files[FILE_KEY] = {} as any;
+      attachCuttings(client, [hollow]);
+
+      const response = await client.v1.getFile(FILE_KEY);
+
+      expect(response.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves fresh copies so consumer mutations cannot corrupt the cutting', async ({
+      client,
+      cutting,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const first = await client.v1.getFile(FILE_KEY);
+      expect(first.data).not.toBe(cutting.data.files[FILE_KEY]);
+
+      first.data.name = 'MUTATED';
+      first.data.document.children.push({} as never);
+
+      const second = await client.v1.getFile(FILE_KEY);
+      expect(second.data.name).toBe(rawFile.name);
+      expect(second.data.document.children).toHaveLength(rawFile.document.children.length);
+      expect(cutting.data.files[FILE_KEY].name).toBe(rawFile.name);
     });
   });
 
@@ -300,6 +393,33 @@ describe('@figmarine/cuttings - attach', () => {
       expect(response.data).toStrictEqual({ reached: 'network' });
       expect(networkAdapter).toHaveBeenCalledTimes(1);
     });
+
+    it('goes to the network when the facet was never hydrated', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      // Hand-written cutting configs may declare facets with no data
+      // behind them; an empty list must never be fabricated for those.
+      const neverHydrated = structuredClone(cutting);
+      neverHydrated.facets = neverHydrated.facets.map((f) =>
+        f.endpoint === 'GetFileComponents' ? { ...f, lastHydrated: 0 } : f,
+      );
+      attachCuttings(client, [neverHydrated]);
+
+      const response = await client.v1.getFileComponents(FILE_KEY);
+
+      expect(response.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes the i18n field real published endpoints return', async ({ client, cutting }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFileStyles(FILE_KEY);
+
+      expect(response.data).toMatchObject({ error: false, i18n: null, status: 200 });
+    });
   });
 
   describe('several cuttings', () => {
@@ -318,6 +438,68 @@ describe('@figmarine/cuttings - attach', () => {
       expect(first.headers[CUTTING_SOURCE_HEADER]).toBe(encodeURIComponent('debug file'));
       expect(second.headers[CUTTING_SOURCE_HEADER]).toBe(encodeURIComponent('error states'));
       expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('lets the most recent attachment win when several hold the same file', async ({
+      client,
+      cutting,
+    }) => {
+      const older = { ...cutting, meta: { ...cutting.meta, label: 'older attachment' } };
+      const newer = { ...cutting, meta: { ...cutting.meta, label: 'newer attachment' } };
+
+      attachCuttings(client, [older]);
+      const detachNewer = attachCuttings(client, [newer]);
+
+      const whileBothAttached = await client.v1.getFile(FILE_KEY);
+      expect(whileBothAttached.headers[CUTTING_SOURCE_HEADER]).toBe(
+        encodeURIComponent('newer attachment'),
+      );
+
+      detachNewer();
+      const afterNewerDetached = await client.v1.getFile(FILE_KEY);
+      expect(afterNewerDetached.headers[CUTTING_SOURCE_HEADER]).toBe(
+        encodeURIComponent('older attachment'),
+      );
+    });
+  });
+
+  describe('development cache interplay', () => {
+    it('serves cuttings over cached network responses, and never persists synthetic responses', async ({
+      cutting,
+      networkAdapter,
+    }) => {
+      const cacheDir = path.join(
+        os.tmpdir(),
+        `figmarine-attach-spec-${process.pid}-${Math.random().toString(36).slice(2)}`,
+      );
+      const client = await Client({
+        personalAccessToken: 'test-token',
+        mode: 'development',
+        cache: { location: cacheDir },
+        rateLimit: false,
+      });
+      client.instance.defaults.adapter = networkAdapter;
+
+      try {
+        // Prime the development cache with a network response.
+        const primed = await client.v1.getFile(FILE_KEY);
+        expect(primed.data).toStrictEqual({ reached: 'network' });
+
+        // The cutting must win over the cached network response.
+        const detach = attachCuttings(client, [cutting]);
+        const served = await client.v1.getFile(FILE_KEY);
+        expect(served.headers[CUTTING_SOURCE_HEADER]).toBe(encodeURIComponent('debug file'));
+        expect(served.data).toStrictEqual(slimFile(rawFile));
+
+        // And the synthetic response must not poison the cache: once
+        // detached, the client returns network(-cached) data again.
+        detach();
+        const afterDetach = await client.v1.getFile(FILE_KEY);
+        expect(afterDetach.headers[CUTTING_SOURCE_HEADER]).toBeUndefined();
+        expect(afterDetach.data).toStrictEqual({ reached: 'network' });
+      } finally {
+        fs.rmSync(cacheDir, { force: true, recursive: true });
+      }
     });
   });
 

--- a/packages/cuttings/src/__tests__/attach.spec.ts
+++ b/packages/cuttings/src/__tests__/attach.spec.ts
@@ -1,0 +1,367 @@
+import { test as base, type Mock } from 'vitest';
+import { Client, type ClientInterface, type V1 } from '@figmarine/rest';
+import type { AxiosAdapter } from 'axios';
+
+import { API_FIXTURE_FILES, loadApiFixture } from '../__fixtures__/api';
+import { attachCuttings, CUTTING_SOURCE_HEADER } from '../attach';
+import { makeMockedClient, mockResponse } from '../__fixtures__/mockedClient';
+import type { Cutting } from '../schemas/cutting';
+import { publishedComponents } from '../__fixtures__/published';
+import { slimFile } from '../slim';
+import { take } from '../take';
+
+/* Logger mock. */
+const { mockedLog } = vi.hoisted(() => ({ mockedLog: vi.fn() }));
+vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
+
+const FILE_KEY = API_FIXTURE_FILES['figma-api-debug-file'];
+const OTHER_FILE_KEY = API_FIXTURE_FILES['error-states'];
+const rawFile = loadApiFixture<V1.GetFile.ResponseBody>('figma-api-debug-file', 'GetFile');
+
+/* Test fixtures: cuttings built from recorded API data, and a real REST
+ * client whose network adapter is replaced by a spy so that no test ever
+ * leaves the process. */
+interface AttachFixtures {
+  cutting: Cutting;
+  client: ClientInterface;
+  networkAdapter: Mock<AxiosAdapter>;
+}
+
+const it = base.extend<AttachFixtures>({
+  cutting: async ({}, use) => {
+    const mocked = makeMockedClient();
+    vi.mocked(mocked.v1.getFileComponents).mockResolvedValueOnce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockResponse({ meta: { components: publishedComponents } }) as any,
+    );
+    const cutting = await take({
+      client: mocked,
+      facets: [
+        { endpoint: 'GetFile', id: FILE_KEY },
+        { endpoint: 'GetFileComponents', id: FILE_KEY },
+        { endpoint: 'GetFileComponentSets', id: FILE_KEY },
+        { endpoint: 'GetFileStyles', id: FILE_KEY },
+      ],
+      label: 'debug file',
+    });
+    await use(cutting);
+  },
+  networkAdapter: async ({}, use) => {
+    await use(
+      vi.fn<AxiosAdapter>(async (config) => ({
+        data: { reached: 'network' },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      })),
+    );
+  },
+  client: async ({ networkAdapter }, use) => {
+    const client = await Client({
+      personalAccessToken: 'test-token',
+      mode: 'production',
+      cache: false,
+      rateLimit: false,
+    });
+    client.instance.defaults.adapter = networkAdapter;
+    await use(client);
+  },
+});
+
+describe('@figmarine/cuttings - attach', () => {
+  describe('GetFile', () => {
+    it('serves a compatible GetFile call from the cutting without touching the network', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFile(FILE_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.data).toStrictEqual(slimFile(rawFile));
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('marks served responses with the cutting source header', async ({ client, cutting }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFile(FILE_KEY);
+
+      expect(response.headers[CUTTING_SOURCE_HEADER]).toBe(encodeURIComponent('debug file'));
+    });
+
+    it('names unlabeled cuttings in the source header', async ({ client, cutting }) => {
+      attachCuttings(client, [{ ...cutting, meta: { ...cutting.meta, label: undefined } }]);
+
+      const response = await client.v1.getFile(FILE_KEY);
+
+      expect(response.headers[CUTTING_SOURCE_HEADER]).toBe('cutting');
+    });
+
+    it('serves calls that ask for branch data', async ({ client, cutting, networkAdapter }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFile(FILE_KEY, { branch_data: true });
+
+      expect(response.data).toStrictEqual(slimFile(rawFile));
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('serves calls that ask for the exact version held in the cutting', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFile(FILE_KEY, { version: rawFile.version });
+
+      expect(response.data).toStrictEqual(slimFile(rawFile));
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('serves version-pinned facets when the call asks for the pinned version', async ({
+      client,
+      networkAdapter,
+    }) => {
+      const mocked = makeMockedClient();
+      const pinned = await take({
+        client: mocked,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY, version: '12345' }],
+      });
+      attachCuttings(client, [pinned]);
+
+      const response = await client.v1.getFile(FILE_KEY, { version: '12345' });
+
+      expect(response.status).toBe(200);
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('goes to the network when the call asks for another version', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFile(FILE_KEY, { version: 'some-other-version' });
+
+      expect(response.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('goes to the network when the cutting is pinned but the call is not', async ({
+      client,
+      networkAdapter,
+    }) => {
+      const mocked = makeMockedClient();
+      const pinned = await take({
+        client: mocked,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY, version: '12345' }],
+      });
+      // The recorded fixture reports its own version; a pinned facet only
+      // matches calls that ask for the pin (or the recorded version).
+      attachCuttings(client, [
+        {
+          ...pinned,
+          data: {
+            ...pinned.data,
+            files: {
+              [FILE_KEY]: { ...pinned.data.files[FILE_KEY], version: '12345' },
+            },
+          },
+        },
+      ]);
+
+      const response = await client.v1.getFile(FILE_KEY);
+
+      expect(response.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('goes to the network when the call uses params the cutting cannot honour', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      await client.v1.getFile(FILE_KEY, { depth: 1 });
+      await client.v1.getFile(FILE_KEY, { ids: '1:2' });
+      await client.v1.getFile(FILE_KEY, { geometry: 'paths' });
+      await client.v1.getFile(FILE_KEY, { plugin_data: 'shared' });
+
+      expect(networkAdapter).toHaveBeenCalledTimes(4);
+    });
+
+    it('goes to the network for files the cutting does not hold', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFile('someOtherFileKey1234');
+
+      expect(response.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('published item endpoints', () => {
+    it('rebuilds GetFileComponents responses from the cutting', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFileComponents(FILE_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.data.error).toBe(false);
+      expect(response.data.meta.components).toHaveLength(publishedComponents.length);
+      expect(response.data.meta.components.map((c) => c.key).sort()).toStrictEqual(
+        publishedComponents.map((c) => c.key).sort(),
+      );
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('only serves published items that belong to the requested file', async ({
+      client,
+      cutting,
+    }) => {
+      const foreignComponent = {
+        ...publishedComponents[0],
+        key: 'foreignComponentKey',
+        file_key: 'someOtherFileKey1234',
+      };
+      const polluted = structuredClone(cutting);
+      polluted.data.components[foreignComponent.key] = foreignComponent;
+      // Pretend the other file's components are also snapshotted.
+      polluted.facets.push({
+        endpoint: 'GetFileComponents',
+        id: 'someOtherFileKey1234',
+        lastHydrated: 1,
+      });
+      attachCuttings(client, [polluted]);
+
+      const response = await client.v1.getFileComponents(FILE_KEY);
+
+      expect(response.data.meta.components.map((c) => c.key)).not.toContain('foreignComponentKey');
+    });
+
+    it('serves an empty list for files that publish nothing', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      // The recorded fixtures publish no component sets: the facet is
+      // hydrated but its data dictionary holds nothing for this file.
+      const response = await client.v1.getFileComponentSets(FILE_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.data.meta.component_sets).toStrictEqual([]);
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('rebuilds GetFileStyles responses from the cutting', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      const response = await client.v1.getFileStyles(FILE_KEY);
+
+      expect(response.status).toBe(200);
+      expect(response.data.meta.styles).toStrictEqual(Object.values(cutting.data.styles));
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+
+    it('goes to the network when the facet was never snapshotted', async ({
+      client,
+      networkAdapter,
+    }) => {
+      const mocked = makeMockedClient();
+      const fileOnly = await take({
+        client: mocked,
+        facets: [{ endpoint: 'GetFile', id: FILE_KEY }],
+      });
+      attachCuttings(client, [fileOnly]);
+
+      const response = await client.v1.getFileComponents(FILE_KEY);
+
+      expect(response.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('several cuttings', () => {
+    it('finds data across all attached cuttings', async ({ client, cutting, networkAdapter }) => {
+      const mocked = makeMockedClient('error-states');
+      const other = await take({
+        client: mocked,
+        facets: [{ endpoint: 'GetFile', id: OTHER_FILE_KEY }],
+        label: 'error states',
+      });
+      attachCuttings(client, [cutting, other]);
+
+      const first = await client.v1.getFile(FILE_KEY);
+      const second = await client.v1.getFile(OTHER_FILE_KEY);
+
+      expect(first.headers[CUTTING_SOURCE_HEADER]).toBe(encodeURIComponent('debug file'));
+      expect(second.headers[CUTTING_SOURCE_HEADER]).toBe(encodeURIComponent('error states'));
+      expect(networkAdapter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pass-through', () => {
+    it('ignores non-GET calls on matching URLs', async ({ client, cutting, networkAdapter }) => {
+      attachCuttings(client, [cutting]);
+
+      await client.instance.post(`/v1/files/${FILE_KEY}`);
+
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores endpoints that cuttings do not snapshot', async ({
+      client,
+      cutting,
+      networkAdapter,
+    }) => {
+      attachCuttings(client, [cutting]);
+
+      await client.instance.get(`/v1/files/${FILE_KEY}/versions`);
+      await client.instance.get(`/v1/files/${FILE_KEY}/nodes`, { params: { ids: '1:2' } });
+      await client.instance.get(`/v1/me`);
+
+      expect(networkAdapter).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops serving once detached', async ({ client, cutting, networkAdapter }) => {
+      const detach = attachCuttings(client, [cutting]);
+
+      const before = await client.v1.getFile(FILE_KEY);
+      detach();
+      const after = await client.v1.getFile(FILE_KEY);
+
+      expect(before.data).toStrictEqual(slimFile(rawFile));
+      expect(after.data).toStrictEqual({ reached: 'network' });
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves nothing when attached with no cuttings', async ({ client, networkAdapter }) => {
+      attachCuttings(client, []);
+
+      await client.v1.getFile(FILE_KEY);
+
+      expect(networkAdapter).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/cuttings/src/__tests__/fs.spec.ts
+++ b/packages/cuttings/src/__tests__/fs.spec.ts
@@ -208,6 +208,18 @@ describe('@figmarine/cuttings - fs', () => {
         'File did not match expected format',
       );
     });
+
+    it('fails if a stored file lost its core fields', ({ fileBasic, fileBasicLocation }) => {
+      // Hand-edits and bad merges must fail at load time, not deep inside
+      // consumers dereferencing the document tree.
+      const hollowed = structuredClone(fileBasic);
+      hollowed.data.files.naoned = {} as (typeof hollowed)['data']['files'][string];
+      vol.fromJSON({ [fileBasicLocation]: JSON.stringify(hollowed) });
+
+      expect(() => digCutting(fileBasicLocation)).toThrowError(
+        'File did not match expected format',
+      );
+    });
   });
 
   describe('chaining', () => {

--- a/packages/cuttings/src/__tests__/hydrate.spec.ts
+++ b/packages/cuttings/src/__tests__/hydrate.spec.ts
@@ -4,6 +4,7 @@ import { test as base } from 'vitest';
 import { API_FIXTURE_FILES, loadApiFixture } from '../__fixtures__/api';
 import type { Cutting } from '../schemas/cutting';
 import { hydrate } from '../hydrate';
+import { mockResponse } from '../__fixtures__/mockedClient';
 import { take } from '../take';
 
 /* Logger mock. */
@@ -13,10 +14,6 @@ vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
 const FILE_KEY = API_FIXTURE_FILES['figma-api-debug-file'];
 const TAKE_TIME = 1751791000000;
 const HYDRATE_TIME = 1751795000000;
-
-function mockResponse<T>(data: T) {
-  return { status: 200, statusText: 'OK', data };
-}
 
 interface HydrateFixtures {
   client: ClientInterface;

--- a/packages/cuttings/src/__tests__/take.spec.ts
+++ b/packages/cuttings/src/__tests__/take.spec.ts
@@ -2,6 +2,7 @@ import type { ClientInterface, V1 } from '@figmarine/rest';
 import { test as base } from 'vitest';
 
 import { API_FIXTURE_FILES, loadApiFixture } from '../__fixtures__/api';
+import { makeMockedClient, mockResponse } from '../__fixtures__/mockedClient';
 import {
   publishedComponents,
   publishedComponentSets,
@@ -17,26 +18,6 @@ vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
 
 const FILE_KEY = API_FIXTURE_FILES['figma-api-debug-file'];
 const NOW = 1751791000000;
-
-/* Test fixtures: a REST client mocked with real recorded API responses. */
-function mockResponse<T>(data: T) {
-  return { status: 200, statusText: 'OK', data };
-}
-
-function makeMockedClient(label: keyof typeof API_FIXTURE_FILES = 'figma-api-debug-file') {
-  return {
-    v1: {
-      getFile: vi.fn(async () => mockResponse(loadApiFixture(label, 'GetFile'))),
-      getFileComponents: vi.fn(async () =>
-        mockResponse(loadApiFixture(label, 'GetFileComponents')),
-      ),
-      getFileComponentSets: vi.fn(async () =>
-        mockResponse(loadApiFixture(label, 'GetFileComponentSets')),
-      ),
-      getFileStyles: vi.fn(async () => mockResponse(loadApiFixture(label, 'GetFileStyles'))),
-    },
-  } as unknown as ClientInterface;
-}
 
 interface TakeFixtures {
   client: ClientInterface;

--- a/packages/cuttings/src/attach.ts
+++ b/packages/cuttings/src/attach.ts
@@ -1,0 +1,226 @@
+import type { ClientInterface } from '@figmarine/rest';
+import type { InternalAxiosRequestConfig } from 'axios';
+import { log } from '@figmarine/logger';
+
+import type { Cutting } from './schemas/cutting';
+import type { ImplementedEndpointType } from './schemas/facet';
+
+/**
+ * Header set on responses that were served from an attached cutting
+ * rather than from the Figma REST API. Its value is the URI-encoded
+ * label of the cutting that answered, or `cutting` when unlabeled.
+ */
+export const CUTTING_SOURCE_HEADER = 'x-figmarine-cutting';
+
+/**
+ * The file-scoped REST API URLs that cuttings can answer for, mapped to
+ * the endpoint type recorded in facets. Query strings never appear here:
+ * the REST client passes query parameters separately.
+ */
+const URL_PATTERNS: readonly [RegExp, ImplementedEndpointType][] = [
+  [/^\/v1\/files\/([^/?#]+)$/, 'GetFile'],
+  [/^\/v1\/files\/([^/?#]+)\/components$/, 'GetFileComponents'],
+  [/^\/v1\/files\/([^/?#]+)\/component_sets$/, 'GetFileComponentSets'],
+  [/^\/v1\/files\/([^/?#]+)\/styles$/, 'GetFileStyles'],
+];
+
+/**
+ * Query parameters of `GetFile` that a cutting can honour. Cuttings store
+ * whole files, so shape-altering parameters (`ids`, `depth`, `geometry`,
+ * `plugin_data`) always fall through to the network.
+ */
+const SERVABLE_GET_FILE_PARAMS = ['branch_data', 'version'];
+
+function safeDecode(str: string): string {
+  try {
+    return decodeURIComponent(str);
+  } catch {
+    return str;
+  }
+}
+
+/**
+ * Returns the query parameters that actually constrain a request, i.e.
+ * those with a meaningful value.
+ */
+function meaningfulParams(params: unknown): Record<string, unknown> {
+  if (typeof params !== 'object' || params === null) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null),
+  );
+}
+
+/**
+ * Finds the cutting able to answer a request, if any.
+ * @param cuttings The attached cuttings.
+ * @param endpoint The endpoint type matched from the request URL.
+ * @param fileKey The file key matched from the request URL.
+ * @param params The request's meaningful query parameters.
+ * @returns The matching cutting, or undefined to fall through to the network.
+ */
+function findServingCutting(
+  cuttings: Cutting[],
+  endpoint: ImplementedEndpointType,
+  fileKey: string,
+  params: Record<string, unknown>,
+): Cutting | undefined {
+  if (endpoint === 'GetFile') {
+    const paramKeys = Object.keys(params);
+    if (paramKeys.some((key) => !SERVABLE_GET_FILE_PARAMS.includes(key))) {
+      return undefined;
+    }
+  } else if (Object.keys(params).length) {
+    // Published item endpoints take no query parameters today; a request
+    // that passes some is asking for something cuttings don't store.
+    return undefined;
+  }
+
+  return cuttings.find((cutting) => {
+    const facet = cutting.facets.find((f) => f.endpoint === endpoint && f.id === fileKey);
+    if (!facet) {
+      return false;
+    }
+
+    if (endpoint === 'GetFile') {
+      const file = cutting.data.files[fileKey];
+      if (!file) {
+        return false;
+      }
+
+      const requestedVersion = params.version;
+      if (requestedVersion === undefined) {
+        // An unversioned call means "latest". Only unpinned facets track
+        // the latest version of a file.
+        return !('version' in facet) || facet.version === undefined;
+      }
+
+      // A versioned call is served when the cutting holds that exact
+      // version, whether through its pin or through the file's own
+      // recorded version.
+      return (
+        requestedVersion === ('version' in facet ? facet.version : undefined) ||
+        requestedVersion === file.version
+      );
+    }
+
+    return true;
+  });
+}
+
+/**
+ * Rebuilds the response body a facet's endpoint would have returned, from
+ * the cutting's stored data.
+ */
+function buildResponseBody(
+  cutting: Cutting,
+  endpoint: ImplementedEndpointType,
+  fileKey: string,
+): unknown {
+  switch (endpoint) {
+    case 'GetFile':
+      return cutting.data.files[fileKey];
+    case 'GetFileComponents':
+      return {
+        error: false,
+        status: 200,
+        meta: {
+          components: Object.values(cutting.data.components).filter((c) => c.file_key === fileKey),
+        },
+      };
+    case 'GetFileComponentSets':
+      return {
+        error: false,
+        status: 200,
+        meta: {
+          component_sets: Object.values(cutting.data.componentSets).filter(
+            (c) => c.file_key === fileKey,
+          ),
+        },
+      };
+    case 'GetFileStyles':
+      return {
+        error: false,
+        status: 200,
+        meta: {
+          styles: Object.values(cutting.data.styles).filter((s) => s.file_key === fileKey),
+        },
+      };
+  }
+}
+
+/**
+ * Attaches cuttings to a `@figmarine/rest` client so that compatible API
+ * calls are served from cutting data instead of the network.
+ *
+ * Compatible calls are `GET` requests to the file-scoped endpoints that
+ * cuttings snapshot (`GetFile`, `GetFileComponents`, `GetFileComponentSets`,
+ * `GetFileStyles`), for a file key held by an attached cutting, with query
+ * parameters the stored data can honour. Anything else falls through to
+ * the network untouched, so a partially-covered client keeps working.
+ *
+ * Served `GetFile` responses contain the cutting's `SlimFile` — the
+ * stored subset of the wire format that excludes volatile and
+ * access-related fields (`thumbnailUrl`, `role`, `linkAccess`…). Served
+ * responses carry the {@link CUTTING_SOURCE_HEADER} response header.
+ *
+ * The cutting is authoritative regardless of its age: refreshing data is
+ * a separate concern, handled by `hydrate` here or by `@figmarine/nursery`
+ * refresh schedules.
+ *
+ * @param client The REST client to attach the cuttings to.
+ * @param cuttings The cuttings to serve API calls from. When several
+ * cuttings can answer a call, the first one in the array wins.
+ * @returns A function that detaches the cuttings from the client.
+ */
+export function attachCuttings(client: ClientInterface, cuttings: Cutting[]): () => void {
+  const interceptorId = client.instance.interceptors.request.use(
+    (config: InternalAxiosRequestConfig) => {
+      const method = config.method?.toLowerCase() ?? 'get';
+      if (method !== 'get' || !config.url) {
+        return config;
+      }
+
+      const [path] = config.url.split(/[?#]/);
+      for (const [pattern, endpoint] of URL_PATTERNS) {
+        const match = path.match(pattern);
+        if (!match) {
+          continue;
+        }
+
+        const fileKey = safeDecode(match[1]);
+        const params = meaningfulParams(config.params);
+        const cutting = findServingCutting(cuttings, endpoint, fileKey, params);
+        if (!cutting) {
+          log(`Cuttings::attachCuttings: no cutting holds ${endpoint}:${fileKey}, calling out.`);
+          return config;
+        }
+
+        log(`Cuttings::attachCuttings: serving ${endpoint}:${fileKey} from a cutting.`);
+        // A per-request adapter short-circuits the network: axios calls it
+        // instead of its HTTP adapter, and response interceptors still run.
+        config.adapter = async (servedConfig) => ({
+          data: buildResponseBody(cutting, endpoint, fileKey),
+          status: 200,
+          statusText: 'OK',
+          headers: {
+            [CUTTING_SOURCE_HEADER]: encodeURIComponent(cutting.meta.label ?? 'cutting'),
+          },
+          config: servedConfig,
+        });
+        return config;
+      }
+
+      return config;
+    },
+  );
+
+  log(`Cuttings::attachCuttings: attached ${cuttings.length} cuttings to a REST client.`);
+
+  return () => {
+    client.instance.interceptors.request.eject(interceptorId);
+    log(`Cuttings::attachCuttings: detached cuttings from a REST client.`);
+  };
+}

--- a/packages/cuttings/src/attach.ts
+++ b/packages/cuttings/src/attach.ts
@@ -31,6 +31,27 @@ const URL_PATTERNS: readonly [RegExp, ImplementedEndpointType][] = [
  */
 const SERVABLE_GET_FILE_PARAMS = ['branch_data', 'version'];
 
+/**
+ * Marks request configs already claimed by an `attachCuttings` interceptor,
+ * so that when several attachments can answer a call, the most recently
+ * attached one wins (request interceptors run most-recent-first) instead of
+ * being silently overwritten by an older attachment.
+ */
+const CUTTING_CLAIM = Symbol('figmarine.cuttings.claim');
+
+/**
+ * The parts of a request config this module reads or writes beyond what
+ * axios types: the claim marker above, and axios-cache-interceptor's
+ * per-request `cache` toggle. Serving sets `cache: false` so that the
+ * development disk cache neither masks attached cuttings with older
+ * network responses nor persists synthetic responses beyond the
+ * attachment's lifetime.
+ */
+type InterceptedRequestConfig = InternalAxiosRequestConfig & {
+  cache?: unknown;
+  [CUTTING_CLAIM]?: boolean;
+};
+
 function safeDecode(str: string): string {
   try {
     return decodeURIComponent(str);
@@ -41,16 +62,51 @@ function safeDecode(str: string): string {
 
 /**
  * Returns the query parameters that actually constrain a request, i.e.
- * those with a meaningful value.
+ * those with a meaningful value, merging the query string embedded in the
+ * request URL with the request's `params`. Returns undefined when the
+ * constraints cannot be fully understood (an exotic `params` object, or
+ * conflicting values for one key) — callers must then fall through to the
+ * network rather than risk serving data the caller did not ask for.
  */
-function meaningfulParams(params: unknown): Record<string, unknown> {
-  if (typeof params !== 'object' || params === null) {
-    return {};
+function requestConstraints(query: string, params: unknown): Record<string, unknown> | undefined {
+  const constraints: Record<string, unknown> = {};
+
+  const mergeEntry = (key: string, value: unknown): boolean => {
+    if (key in constraints && String(constraints[key]) !== String(value)) {
+      return false;
+    }
+    constraints[key] = value;
+    return true;
+  };
+
+  for (const [key, value] of new URLSearchParams(query)) {
+    if (!mergeEntry(key, value)) {
+      return undefined;
+    }
   }
 
-  return Object.fromEntries(
-    Object.entries(params).filter(([, value]) => value !== undefined && value !== null),
-  );
+  let paramEntries: [string, unknown][];
+  if (params === undefined || params === null) {
+    paramEntries = [];
+  } else if (params instanceof URLSearchParams) {
+    paramEntries = [...params.entries()];
+  } else if (typeof params === 'object' && Object.getPrototypeOf(params) === Object.prototype) {
+    paramEntries = Object.entries(params);
+  } else {
+    // Custom params containers can serialise to anything; never guess.
+    return undefined;
+  }
+
+  for (const [key, value] of paramEntries) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (!mergeEntry(key, value)) {
+      return undefined;
+    }
+  }
+
+  return constraints;
 }
 
 /**
@@ -86,7 +142,15 @@ function findServingCutting(
 
     if (endpoint === 'GetFile') {
       const file = cutting.data.files[fileKey];
-      if (!file) {
+      // Loose schemas tolerate hand-edited cuttings whose stored files
+      // miss core fields; those cannot stand in for a GetFile response.
+      if (
+        !file ||
+        typeof file.name !== 'string' ||
+        typeof file.version !== 'string' ||
+        typeof file.document !== 'object' ||
+        file.document === null
+      ) {
         return false;
       }
 
@@ -106,7 +170,10 @@ function findServingCutting(
       );
     }
 
-    return true;
+    // Facets that were never hydrated (e.g. hand-written cutting configs)
+    // have no data behind them: an empty published list must mean "this
+    // file publishes nothing", never "this was never fetched".
+    return (facet.lastHydrated ?? 0) > 0;
   });
 }
 
@@ -125,6 +192,7 @@ function buildResponseBody(
     case 'GetFileComponents':
       return {
         error: false,
+        i18n: null,
         status: 200,
         meta: {
           components: Object.values(cutting.data.components).filter((c) => c.file_key === fileKey),
@@ -133,6 +201,7 @@ function buildResponseBody(
     case 'GetFileComponentSets':
       return {
         error: false,
+        i18n: null,
         status: 200,
         meta: {
           component_sets: Object.values(cutting.data.componentSets).filter(
@@ -143,6 +212,7 @@ function buildResponseBody(
     case 'GetFileStyles':
       return {
         error: false,
+        i18n: null,
         status: 200,
         meta: {
           styles: Object.values(cutting.data.styles).filter((s) => s.file_key === fileKey),
@@ -168,22 +238,31 @@ function buildResponseBody(
  *
  * The cutting is authoritative regardless of its age: refreshing data is
  * a separate concern, handled by `hydrate` here or by `@figmarine/nursery`
- * refresh schedules.
+ * refresh schedules. Served requests bypass the client's development
+ * cache both ways: cached network responses do not mask cuttings, and
+ * synthetic responses are never persisted.
  *
  * @param client The REST client to attach the cuttings to.
  * @param cuttings The cuttings to serve API calls from. When several
- * cuttings can answer a call, the first one in the array wins.
+ * cuttings can answer a call, the first one in the array wins; when
+ * several attachments can, the most recently attached wins.
  * @returns A function that detaches the cuttings from the client.
  */
 export function attachCuttings(client: ClientInterface, cuttings: Cutting[]): () => void {
   const interceptorId = client.instance.interceptors.request.use(
-    (config: InternalAxiosRequestConfig) => {
+    (config: InterceptedRequestConfig) => {
       const method = config.method?.toLowerCase() ?? 'get';
-      if (method !== 'get' || !config.url) {
+      if (method !== 'get' || !config.url || config[CUTTING_CLAIM]) {
         return config;
       }
 
-      const [path] = config.url.split(/[?#]/);
+      // Constraints can hide in the URL's own query string, not just in
+      // `params` — never discard them.
+      const [beforeHash] = config.url.split('#');
+      const queryIndex = beforeHash.indexOf('?');
+      const path = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+      const query = queryIndex === -1 ? '' : beforeHash.slice(queryIndex + 1);
+
       for (const [pattern, endpoint] of URL_PATTERNS) {
         const match = path.match(pattern);
         if (!match) {
@@ -191,18 +270,27 @@ export function attachCuttings(client: ClientInterface, cuttings: Cutting[]): ()
         }
 
         const fileKey = safeDecode(match[1]);
-        const params = meaningfulParams(config.params);
-        const cutting = findServingCutting(cuttings, endpoint, fileKey, params);
+        const constraints = requestConstraints(query, config.params);
+        const cutting = constraints && findServingCutting(cuttings, endpoint, fileKey, constraints);
         if (!cutting) {
           log(`Cuttings::attachCuttings: no cutting holds ${endpoint}:${fileKey}, calling out.`);
           return config;
         }
 
         log(`Cuttings::attachCuttings: serving ${endpoint}:${fileKey} from a cutting.`);
+        config[CUTTING_CLAIM] = true;
+        // Keep the development request cache out of the loop: a cache hit
+        // would replace the adapter below with an older network response,
+        // and a cache write would persist the synthetic response beyond
+        // this attachment's lifetime.
+        config.cache = false;
         // A per-request adapter short-circuits the network: axios calls it
         // instead of its HTTP adapter, and response interceptors still run.
         config.adapter = async (servedConfig) => ({
-          data: buildResponseBody(cutting, endpoint, fileKey),
+          // Cloned like a real response is a fresh parse: consumers that
+          // mutate response bodies must not corrupt the cutting or later
+          // responses.
+          data: structuredClone(buildResponseBody(cutting, endpoint, fileKey)),
           status: 200,
           statusText: 'OK',
           headers: {

--- a/packages/cuttings/src/index.ts
+++ b/packages/cuttings/src/index.ts
@@ -1,5 +1,6 @@
 export * from './schemas/cutting';
 export * from './schemas/facet';
+export * from './attach';
 export * from './figmaUrl';
 export * from './fs';
 export * from './hydrate';

--- a/packages/cuttings/src/schemas/cutting.ts
+++ b/packages/cuttings/src/schemas/cutting.ts
@@ -49,7 +49,18 @@ export const CuttingSchema = z.object({
   data: z.object({
     components: z.record(z.string(), z.looseObject({})),
     componentSets: z.record(z.string(), z.looseObject({})),
-    files: z.record(z.string(), z.looseObject({})),
+    // Stored files are slim but never hollow: consumers dereference at
+    // least the document tree, so a cutting whose file data lost its core
+    // fields (hand-edits, bad merges) must fail at load time, not deep
+    // inside consumer code.
+    files: z.record(
+      z.string(),
+      z.looseObject({
+        document: z.looseObject({}),
+        name: z.string(),
+        version: z.string(),
+      }),
+    ),
     localVariables: z.record(z.string(), z.looseObject({})),
     localVariableCollections: z.record(z.string(), z.looseObject({})),
     projects: z.record(z.string(), z.looseObject({})),

--- a/packages/cuttings/src/schemas/facet.ts
+++ b/packages/cuttings/src/schemas/facet.ts
@@ -50,6 +50,11 @@ export const IMPLEMENTED_ENDPOINT_TYPES = [
 ] as const satisfies readonly (typeof ALL_ENDPOINT_TYPES)[number][];
 
 /**
+ * An endpoint type that `take` can currently fetch.
+ */
+export type ImplementedEndpointType = (typeof IMPLEMENTED_ENDPOINT_TYPES)[number];
+
+/**
  * The last time a facet's data was fetched through the Figma REST API,
  * as a Unix epoch in milliseconds. Zero when never fetched, e.g. in a
  * hand-written cutting config that was not taken yet.

--- a/packages/nursery/README.md
+++ b/packages/nursery/README.md
@@ -123,6 +123,39 @@ mornings and open a pull request when Figma content changed:
 
 Each template documents its own caveats in its header comments.
 
+### Serving REST API calls from the nursery
+
+Programs that use `@figmarine/rest` can read planted data transparently:
+`connectNursery` attaches every planted cutting to a client, and compatible
+API calls are then served from disk instead of the network (see the
+[cuttings documentation](../cuttings/README.md#serving-api-calls-from-cuttings)
+for what counts as compatible — everything else keeps hitting the network).
+
+```ts
+import { Client } from '@figmarine/rest';
+import { connectNursery, refresh, status } from '@figmarine/nursery';
+
+const client = await Client({ personalAccessToken: process.env.FIGMA_PERSONAL_ACCESS_TOKEN });
+
+const { disconnect } = connectNursery(client);
+const file = await client.v1.getFile(fileKey); // Served from .figmarine/cuttings/.
+disconnect();
+```
+
+Connecting never triggers network calls: planted cuttings are served as-is,
+however old, so runs are deterministic and work offline. When your use case
+needs fresh data, check and refresh explicitly before connecting — the CLI
+commands are also exported as library functions:
+
+```ts
+// Flag cuttings older than a day, re-fetch just those, then connect.
+const stale = status({ maxAgeSeconds: 86_400 }).filter((s) => s.stale);
+if (stale.length) {
+  await refresh({ names: stale.map((s) => s.name) });
+}
+connectNursery(client);
+```
+
 ### Driving the CLI from Claude Code
 
 The package ships a [Claude Code skill](./templates/claude-skill/figma-cuttings/SKILL.md)
@@ -138,6 +171,7 @@ conversationally. Copy the `figma-cuttings` directory into your repository's
 - [x] GitHub Actions workflow template for scheduled refreshes
 - [x] CircleCI workflow template
 - [x] Claude Code skill wrapping the CLI
+- [x] Serve REST client calls from planted cuttings (`connectNursery`)
 - [x] Automate NPM releases
 
 ## :wave: Contributing

--- a/packages/nursery/src/__tests__/connect.spec.ts
+++ b/packages/nursery/src/__tests__/connect.spec.ts
@@ -1,0 +1,115 @@
+import type { ClientInterface } from '@figmarine/rest';
+import { vol } from 'memfs';
+
+import { debugFileConfig, debugFileCutting } from '../__fixtures__/cutting';
+import { connectNursery } from '../connect';
+
+/* FS mocks. */
+vi.mock('node:fs');
+vi.mock('node:fs/promises');
+
+/* Logger mock. */
+const { mockedLog } = vi.hoisted(() => ({ mockedLog: vi.fn() }));
+vi.mock(import('@figmarine/logger'), async () => ({ log: mockedLog }));
+
+/* Cuttings mock: attaching and digging are exercised by the cuttings
+ * package's own tests. */
+const { mockedAttach, mockedDetach, mockedDig } = vi.hoisted(() => {
+  const mockedDetach = vi.fn();
+  return {
+    mockedAttach: vi.fn(() => mockedDetach),
+    mockedDetach,
+    mockedDig: vi.fn(),
+  };
+});
+vi.mock(import('@figmarine/cuttings'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return { ...mod, attachCuttings: mockedAttach, digCutting: mockedDig };
+});
+
+const CONFIG_PATH = '/repo/.figmarine/nursery.json';
+const CUTTING_PATH = '/repo/.figmarine/cuttings/debug-file.cutting.figmarine.json';
+const mockedClient = { v1: {} } as unknown as ClientInterface;
+
+const twoCuttingsConfig = {
+  cuttings: {
+    ...debugFileConfig.cuttings,
+    'error-states': {
+      files: [{ url: 'https://www.figma.com/design/3qv1uKfLSXm4etqj005Rmi/Error-States' }],
+    },
+  },
+};
+const ERROR_STATES_PATH = '/repo/.figmarine/cuttings/error-states.cutting.figmarine.json';
+
+describe('@figmarine/nursery - connectNursery', () => {
+  beforeEach(() => {
+    vol.reset();
+    vol.fromJSON({
+      [CONFIG_PATH]: JSON.stringify(debugFileConfig),
+      [CUTTING_PATH]: JSON.stringify(debugFileCutting),
+    });
+    mockedDig.mockReturnValue(structuredClone(debugFileCutting));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    mockedAttach.mockClear();
+    mockedDetach.mockClear();
+    mockedDig.mockReset();
+  });
+
+  it('digs every configured cutting and attaches them to the client', () => {
+    const connection = connectNursery(mockedClient, { configPath: CONFIG_PATH });
+
+    expect(mockedDig).toHaveBeenCalledExactlyOnceWith(CUTTING_PATH);
+    expect(mockedAttach).toHaveBeenCalledExactlyOnceWith(mockedClient, [
+      expect.objectContaining({ meta: expect.objectContaining({ label: 'debug file' }) }),
+    ]);
+    expect(connection.locations).toStrictEqual([CUTTING_PATH]);
+    expect(connection.cuttings).toHaveLength(1);
+  });
+
+  it('returns the detach function of the underlying attachment', () => {
+    const connection = connectNursery(mockedClient, { configPath: CONFIG_PATH });
+
+    expect(mockedDetach).not.toHaveBeenCalled();
+    connection.disconnect();
+    expect(mockedDetach).toHaveBeenCalledTimes(1);
+  });
+
+  it('only connects the named cuttings when names are given', () => {
+    vol.fromJSON({
+      [CONFIG_PATH]: JSON.stringify(twoCuttingsConfig),
+      [ERROR_STATES_PATH]: JSON.stringify(debugFileCutting),
+    });
+
+    const connection = connectNursery(mockedClient, {
+      configPath: CONFIG_PATH,
+      names: ['error-states'],
+    });
+
+    expect(connection.locations).toStrictEqual([ERROR_STATES_PATH]);
+    expect(mockedDig).toHaveBeenCalledExactlyOnceWith(ERROR_STATES_PATH);
+  });
+
+  it('throws when a selected cutting was never planted', () => {
+    vol.fromJSON({ [CONFIG_PATH]: JSON.stringify(twoCuttingsConfig) });
+
+    expect(() =>
+      connectNursery(mockedClient, { configPath: CONFIG_PATH, names: ['error-states'] }),
+    ).toThrowError(/'error-states' is not planted at .* Run 'nursery take error-states' first/);
+    expect(mockedAttach).not.toHaveBeenCalled();
+  });
+
+  it('throws on unknown cutting names', () => {
+    expect(() =>
+      connectNursery(mockedClient, { configPath: CONFIG_PATH, names: ['nope'] }),
+    ).toThrowError('no cuttings named: nope');
+  });
+
+  it('throws when there is no config file', () => {
+    expect(() =>
+      connectNursery(mockedClient, { configPath: '/nowhere/nursery.json' }),
+    ).toThrowError(/no config found/);
+    expect(mockedAttach).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nursery/src/__tests__/plan.spec.ts
+++ b/packages/nursery/src/__tests__/plan.spec.ts
@@ -51,6 +51,25 @@ describe('@figmarine/nursery - plan', () => {
       ]);
     });
 
+    it('plans published-item facets against the main file for branch URLs', () => {
+      // Published-item endpoints only accept main file keys, and Figma
+      // reports published items under the main file's key.
+      const facets = planFacets({
+        files: [
+          {
+            url: 'https://www.figma.com/design/idLa6ZCXDJUeRFI5wLVNWN/branch/aBcD1234eFgH/Steve-s-Figma-API-debug-file',
+            endpoints: ['GetFile', 'GetFileComponents', 'GetFileStyles'],
+          },
+        ],
+      });
+
+      expect(facets).toStrictEqual([
+        { endpoint: 'GetFile', id: 'aBcD1234eFgH' },
+        { endpoint: 'GetFileComponents', id: 'idLa6ZCXDJUeRFI5wLVNWN' },
+        { endpoint: 'GetFileStyles', id: 'idLa6ZCXDJUeRFI5wLVNWN' },
+      ]);
+    });
+
     it('throws on invalid Figma URLs', () => {
       expect(() =>
         planFacets({ files: [{ url: 'https://example.com/nope', endpoints: ['GetFile'] }] }),

--- a/packages/nursery/src/connect.ts
+++ b/packages/nursery/src/connect.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs';
+
+import { attachCuttings, type Cutting, digCutting } from '@figmarine/cuttings';
+import type { ClientInterface } from '@figmarine/rest';
+import { log } from '@figmarine/logger';
+
+import { cuttingPath, DEFAULT_CONFIG_PATH, loadConfig, selectCuttings } from './config';
+
+/**
+ * Options for {@link connectNursery}.
+ */
+export interface ConnectNurseryOptions {
+  /**
+   * Names of the cuttings to connect. Connects every configured cutting
+   * when empty.
+   */
+  names?: string[];
+
+  /**
+   * Path to the nursery config file.
+   */
+  configPath?: string;
+}
+
+/**
+ * A live connection between a nursery and a REST client.
+ */
+export interface NurseryConnection {
+  /**
+   * The cuttings that were attached to the client.
+   */
+  cuttings: Cutting[];
+
+  /**
+   * The paths the attached cuttings were loaded from.
+   */
+  locations: string[];
+
+  /**
+   * Detaches the cuttings from the client. Subsequent API calls all go to
+   * the network again.
+   */
+  disconnect: () => void;
+}
+
+/**
+ * Connects a `@figmarine/rest` client to the nursery: loads the planted
+ * cuttings named by the nursery config and attaches them to the client,
+ * so that compatible API calls are served from planted data instead of
+ * the network. Incompatible or uncovered calls keep going to the network.
+ *
+ * Planted cuttings are authoritative regardless of age — connecting never
+ * triggers network calls. Check freshness separately with `status` (its
+ * `maxAgeSeconds` option flags stale cuttings) and re-fetch with `refresh`
+ * before connecting when your use case needs recent data.
+ *
+ * @param client The REST client to connect.
+ * @param options See {@link ConnectNurseryOptions}.
+ * @throws When the config is missing or invalid, when a name is unknown,
+ * or when a selected cutting was never planted.
+ * @returns See {@link NurseryConnection}.
+ */
+export function connectNursery(
+  client: ClientInterface,
+  { names, configPath = DEFAULT_CONFIG_PATH }: ConnectNurseryOptions = {},
+): NurseryConnection {
+  const config = loadConfig(configPath);
+  const selected = selectCuttings(config, names, configPath);
+
+  const cuttings: Cutting[] = [];
+  const locations: string[] = [];
+  for (const [name] of selected) {
+    const location = cuttingPath(config, name);
+    if (!fs.existsSync(location)) {
+      throw new Error(
+        `Nursery::connectNursery: cutting '${name}' is not planted at '${location}'. Run 'nursery take ${name}' first.`,
+      );
+    }
+
+    cuttings.push(digCutting(location));
+    locations.push(location);
+  }
+
+  log(`Nursery::connectNursery: connecting ${cuttings.length} planted cuttings to a client.`);
+  const disconnect = attachCuttings(client, cuttings);
+
+  return { cuttings, locations, disconnect };
+}

--- a/packages/nursery/src/connect.ts
+++ b/packages/nursery/src/connect.ts
@@ -37,8 +37,8 @@ export interface NurseryConnection {
   locations: string[];
 
   /**
-   * Detaches the cuttings from the client. Subsequent API calls all go to
-   * the network again.
+   * Detaches the cuttings from the client, which then behaves as if the
+   * nursery was never connected.
    */
   disconnect: () => void;
 }

--- a/packages/nursery/src/index.ts
+++ b/packages/nursery/src/index.ts
@@ -1,4 +1,5 @@
 export * from './client';
+export * from './connect';
 export * from './commands/init';
 export * from './commands/refresh';
 export * from './commands/status';

--- a/packages/nursery/src/plan.ts
+++ b/packages/nursery/src/plan.ts
@@ -18,15 +18,19 @@ export function planFacets(entry: ResolvedNurseryCutting): Facet[] {
   const facets = new Map<string, Facet>();
 
   for (const file of entry.files) {
-    const { fileKey } = parseFigmaUrl(file.url);
+    const { fileKey, mainFileKey } = parseFigmaUrl(file.url);
 
     for (const endpoint of file.endpoints) {
+      // Published-item endpoints only accept main file keys, and their
+      // items always report the main file's key. For a branch URL, plan
+      // them against the main file so facets and data stay coherent.
+      const id = endpoint === 'GetFile' ? fileKey : (mainFileKey ?? fileKey);
       const facet: Facet =
         endpoint === 'GetFile' && file.version !== undefined
-          ? { endpoint, id: fileKey, version: file.version }
-          : { endpoint, id: fileKey };
+          ? { endpoint, id, version: file.version }
+          : { endpoint, id };
 
-      facets.set(`${endpoint}:${fileKey}`, facet);
+      facets.set(`${endpoint}:${id}`, facet);
     }
   }
 

--- a/packages/rest/src/__tests__/interceptors.spec.ts
+++ b/packages/rest/src/__tests__/interceptors.spec.ts
@@ -170,5 +170,27 @@ describe('@figmarine/rest - interceptors', () => {
       expect(rlSpy).not.toHaveBeenCalled();
       expect(cfg.reqLog).toHaveLength(0);
     });
+
+    it('skips rate limiting for requests served by a per-request adapter', async ({ cache }) => {
+      const rlSpy = vi.spyOn(rateLimitModule, 'interceptRequest');
+      const cfg = getConfig();
+      const hasSpy = vi.spyOn(cache, 'has');
+
+      const interceptor = rateLimitRequestInterceptor(cache);
+      const locallyServed: InternalAxiosRequestConfig = {
+        ...fileRequest,
+        adapter: async (config) => ({
+          data: {},
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config,
+        }),
+      };
+      await interceptor(locallyServed);
+      expect(rlSpy).not.toHaveBeenCalled();
+      expect(hasSpy).not.toHaveBeenCalled();
+      expect(cfg.reqLog).toHaveLength(0);
+    });
   });
 });

--- a/packages/rest/src/__tests__/interceptors.spec.ts
+++ b/packages/rest/src/__tests__/interceptors.spec.ts
@@ -1,6 +1,6 @@
 import os from 'node:os';
 
-import type { AxiosRequestHeaders, InternalAxiosRequestConfig } from 'axios';
+import type { AxiosInstance, AxiosRequestHeaders, InternalAxiosRequestConfig } from 'axios';
 import { test as base } from 'vitest';
 import { faker } from '@faker-js/faker';
 import { vol } from 'memfs';
@@ -191,6 +191,30 @@ describe('@figmarine/rest - interceptors', () => {
       expect(rlSpy).not.toHaveBeenCalled();
       expect(hasSpy).not.toHaveBeenCalled();
       expect(cfg.reqLog).toHaveLength(0);
+    });
+
+    it('still rate limits when the function adapter is the instance default', async ({ cache }) => {
+      const rlSpy = vi.spyOn(rateLimitModule, 'interceptRequest');
+      const cfg = getConfig();
+
+      // Consumers may install a custom network transport as the default
+      // adapter of the whole instance; those requests do hit the network.
+      const customTransport = async (config: InternalAxiosRequestConfig) => ({
+        data: {},
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config,
+      });
+      const instance = { defaults: { adapter: customTransport } } as unknown as AxiosInstance;
+      const interceptor = rateLimitRequestInterceptor(cache, instance);
+      const throughCustomTransport: InternalAxiosRequestConfig = {
+        ...fileRequest,
+        adapter: customTransport,
+      };
+      await interceptor(throughCustomTransport);
+      expect(rlSpy).toHaveBeenCalled();
+      expect(cfg.reqLog).toHaveLength(1);
     });
   });
 });

--- a/packages/rest/src/client.ts
+++ b/packages/rest/src/client.ts
@@ -116,7 +116,9 @@ export async function Client(opts: ClientOptions = {}): Promise<ClientInterface>
 
     if (rateLimit === true || rateLimit === 'proactive') {
       log('Applying proactive rate limit (limiting req/s).');
-      api.instance.interceptors.request.use(rateLimitRequestInterceptor(cacheInstance));
+      api.instance.interceptors.request.use(
+        rateLimitRequestInterceptor(cacheInstance, api.instance),
+      );
     }
 
     // Add response interceptor for 429 handling.

--- a/packages/rest/src/interceptors.ts
+++ b/packages/rest/src/interceptors.ts
@@ -1,4 +1,4 @@
-import type { InternalAxiosRequestConfig } from 'axios';
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { log } from '@figmarine/logger';
 
 import { Cache, generatePredictableKey } from './cache';
@@ -76,12 +76,14 @@ export function cacheInvalidationRequestInterceptor(cache: Cache) {
   };
 }
 
-export function rateLimitRequestInterceptor(cache: Cache | undefined) {
+export function rateLimitRequestInterceptor(cache: Cache | undefined, instance?: AxiosInstance) {
   return async function (config: InternalAxiosRequestConfig) {
     // A per-request function adapter means the response is produced
     // locally (e.g. by @figmarine/cuttings serving planted data), so no
-    // rate limit budget is consumed.
-    if (typeof config.adapter === 'function') {
+    // rate limit budget is consumed. A function adapter inherited from the
+    // instance defaults is different: that is how consumers install custom
+    // transports, and those requests do reach the network.
+    if (typeof config.adapter === 'function' && config.adapter !== instance?.defaults.adapter) {
       return config;
     }
 

--- a/packages/rest/src/interceptors.ts
+++ b/packages/rest/src/interceptors.ts
@@ -78,6 +78,13 @@ export function cacheInvalidationRequestInterceptor(cache: Cache) {
 
 export function rateLimitRequestInterceptor(cache: Cache | undefined) {
   return async function (config: InternalAxiosRequestConfig) {
+    // A per-request function adapter means the response is produced
+    // locally (e.g. by @figmarine/cuttings serving planted data), so no
+    // rate limit budget is consumed.
+    if (typeof config.adapter === 'function') {
+      return config;
+    }
+
     // If we have cache for the request, no need to consider rate limiting.
     const cacheHit = cache && (await cache.has(generatePredictableKey(config)));
 


### PR DESCRIPTION
# REST client ⇄ nursery: transparent offline consumption of cuttings

Implements the new project goal: a `@figmarine/rest` client can connect to a nursery and serve compatible API calls from planted cuttings, transparently — the calling code doesn't change at all.

## Design (as agreed)

Split placement keeping the dependency graph acyclic (`rest ← cuttings ← nursery`):

- **`@figmarine/cuttings` owns the mechanics** — `attachCuttings(client, cuttings): detach`. A request interceptor on the client's shared axios instance answers compatible `GET` calls by swapping in a per-request adapter that returns a synthetic 200 built from cutting data. Everything else (other endpoints, `POST`s, shape-altering params) falls through untouched, so a partially-covered client keeps working. Reusable by any cuttings consumer (e.g. `eslint-plugin-figma`) without pulling in the nursery.
- **`@figmarine/nursery` owns the sugar** — `connectNursery(client, { configPath?, names? })` digs every planted cutting from `.figmarine/` and attaches them; returns `{ cuttings, locations, disconnect }`.
- **`@figmarine/rest` stays cuttings-agnostic** — one generic change: the proactive rate limiter skips requests that carry a per-request function adapter (they never reach the network, so they consume no budget).

Per your guidance, **freshness is a separate programmatic surface, not a connect option**: connecting never triggers network calls — planted cuttings are authoritative however old, so runs are deterministic and offline-capable. The exported `status({ maxAgeSeconds })` and `refresh({ names })` library functions are the force-refresh/staleness APIs, and the READMEs document the check-then-refresh-then-connect recipe.

## Compatibility rules (strict by default)

| Call | Served when |
| --- | --- |
| `GetFile` | cutting holds the file (with its core fields intact); no `ids`/`depth`/`geometry`/`plugin_data`; unversioned call ⇒ unpinned facet; versioned call ⇒ matches facet pin or stored file version |
| `GetFileComponents` / `ComponentSets` / `Styles` | facet snapshotted **and hydrated** for that file key; published items filtered by `file_key` |

Served responses carry an `x-figmarine-cutting` header (exported as `CUTTING_SOURCE_HEADER`) naming the answering cutting; file bodies are the documented `SlimFile` subset, cloned per request like a real parse.

## Verified live against the real Figma API

Using the 53MB cutting planted in the nursery PR's live run: `connectNursery` + full-featured client (proactive rate limit ON) → `GetFile` served in ~300ms with **zero network calls and zero rate-limit budget** (~100× faster than the live fetch; the ~300ms is the per-request clone of a 53MB body, the price of mutation safety); `GetFile?depth=1` fell through to the live API (200, live-only fields present); `disconnect()` restored networking.

## Testing

39 new tests, TDD on the recorded real-data fixtures:

- `cuttings/attach.spec.ts` (29): exercises a **real** `Client` instance (axios pipeline included) with a spy network adapter — serving, header marking, version pin/unpinned × versioned/unversioned matrix, param fall-throughs (`params`, URL-embedded query, `URLSearchParams`, unintrospectable containers), dev-cache interplay, `file_key` filtering with cross-file pollution, empty published lists, never-hydrated facets, hollow files, mutation isolation, multi-cutting and multi-attachment precedence, detach, non-GET/unknown-URL pass-through.
- `nursery/connect.spec.ts` (6): config/name selection, not-planted and missing-config errors, detach plumbing.
- `rest/interceptors.spec.ts` (+2): rate limiter ignores per-request adapters but still throttles instance-default function adapters.
- Shared mocked-client fixture extracted (`__fixtures__/mockedClient.ts`); one new `digCutting` validation test; one new branch-URL planning test.

## Review notes

Thermonuclear review: 2 adversarial finder agents (correctness lens / API-contract lens), every finding empirically reproduced before fixing, and every fix re-verified by re-running the reviewers' own repro scripts against the rebuilt packages. Confirmed and fixed:

- **The dev-mode disk cache both masked cuttings and got poisoned by them** (found by both reviewers, reproduced): axios-cache-interceptor overwrites per-request adapters on cache hits, and stored synthetic responses with a ~1-year TTL — a dev-mode consumer would keep getting slim snapshot bodies from cache long after disconnecting. Served requests now set `cache: false`, cutting the dev cache out in both directions.
- **Constraints hidden in the URL query string or passed as `URLSearchParams` were discarded** — `instance.get('/v1/files/K?version=9999')` served the wrong version as a confident 200. Constraints are now merged from URL + params; unintrospectable params containers fall through.
- **The rate-limit skip was over-broad**: any client with a custom instance-default function adapter (custom transports) silently lost all proactive throttling. Now only per-request adapters skip.
- **Never-hydrated published facets fabricated confident empty lists** (hand-written cutting configs are a supported state) — now they fall through.
- **Served bodies aliased the cutting's live objects**: consumer mutations corrupted later responses and the snapshot itself (reproduced through to `plantCutting`). Bodies are now cloned per request.
- **Hollow stored files** (hand-edits/bad merges passing the loose schema) crashed typed consumers deep in rule code — now rejected at `digCutting` time and refused by the interceptor.
- **Branch-URL nursery entries planned published-item facets against branch keys**, which Figma's published endpoints don't accept — now planned against the main file key, keeping facet ids and stored `file_key`s coherent.
- Doc fidelity: synthetic published bodies now include the `i18n: null` field real responses carry; the README spells out the `SlimFile` deletions the type system can't express (`role` et al. are typed required but `undefined` on served responses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6uuNuww7pz54s1eV4dv2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6uuNuww7pz54s1eV4dv2e)_